### PR TITLE
feat: expandable history notes + Insights as project landing

### DIFF
--- a/internal/webapp/static/app.js
+++ b/internal/webapp/static/app.js
@@ -166,7 +166,12 @@ function selectProject(p, path) {
   initUpload();
   initHistory();
   updateShareButton();
-  refreshTree().then(() => { if (path) openPath(path); });
+  refreshTree().then(() => {
+    if (path) openPath(path);
+    // Landing view: admins/owners get the Insights dashboard instead of an
+    // empty "select a file" pane; members keep the placeholder.
+    else if (canSeeInsights()) showInsights();
+  });
   if (!path) pushURL("/" + p.id);
 }
 
@@ -1543,6 +1548,18 @@ function historyEntryRow(e) {
         note.append(tok);
       }
     }
+    // Long notes clamp to one line; clicking the note (links still work)
+    // expands to the full text and back.
+    note.tabIndex = 0;
+    note.setAttribute("role", "button");
+    note.title = "Show full note";
+    note.onclick = (ev) => {
+      if (ev.target.tagName === "A") return;
+      const open = note.classList.toggle("open");
+      note.title = open ? "Collapse note" : "Show full note";
+      note.setAttribute("aria-expanded", String(open));
+    };
+    note.onkeydown = (ev) => { if (ev.key === "Enter" || ev.key === " ") { ev.preventDefault(); note.click(); } };
     row.appendChild(note);
   }
   const p = e.path;

--- a/internal/webapp/static/style.css
+++ b/internal/webapp/static/style.css
@@ -347,7 +347,9 @@ button, input, a.btn { font-family: inherit; }
 .hact { margin-left: auto; }
 .hact a { color: var(--accent-bright); text-decoration: none; margin-left: 10px; }
 .hact a:hover { text-decoration: underline; }
-.hnote { margin-top: 4px; padding-left: 23px; font-size: 12px; color: var(--text-faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.hnote { margin-top: 4px; padding-left: 23px; font-size: 12px; color: var(--text-faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; cursor: pointer; }
+.hnote:hover { color: var(--text); }
+.hnote.open { white-space: normal; overflow-wrap: anywhere; }
 .hnote::before { content: "› "; color: var(--text-ghost); }
 .hnote a { color: var(--accent-bright); text-decoration: none; }
 .hnote a:hover { text-decoration: underline; }


### PR DESCRIPTION
Two UX improvements from hands-on demo feedback:

- **Expandable notes**: history notes clamp to one line (feed stays scannable) and now expand/collapse on click or Enter — keyboard-accessible, links inside the note still work. Long intent notes ("why this change happened" + session URL) are fully readable in place.
- **Insights landing**: selecting a project lands hub admins / org owners on the Insights dashboard instead of the empty "Select a file to read it." pane. Members keep the placeholder; deep links with a path still open that file/folder. Fixes the discoverability of Insights being buried behind the ⋯ menu.

Verified hands-on against the seeded 500-file demo hub: note truncation/expand/collapse measured, link clicks don't toggle, login→project lands on the treemap with zero clicks, file deep links unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5cxPQdSGJnjXCYY9GeWXt