### PR TITLE
Landing chat mockup: gated team link by default, public only on request

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -446,9 +446,11 @@ every tool works          content-addressed blobs    append-only, no locks, offl
         <div class="bubble">Write up the Q3 findings and share them with the team.</div>
       </div>
       <div class="msg claude"><div class="who">Your Claude</div>
-        <div class="bubble">Done — I saved the report to <code>wiki/q3-findings.md</code>
-        (synced to the team) and here's a public link for anyone outside it:<br><br>
-        <span class="url">https://acme-hub.example/s/1aad3327224e408d…</span></div>
+        <div class="bubble">Done — I saved the report to <code>wiki/q3-findings.md</code>.
+        It's already syncing to the team; here's the link (sign-in required, so
+        it's safe to paste anywhere):<br><br>
+        <span class="url">https://acme-hub.example/p-1a2b3c4d/wiki/q3-findings.md</span><br><br>
+        Say the word if you need a public link for someone outside the team.</div>
       </div>
       <div class="msg"><div class="who">Your teammate, to their Claude</div>
         <div class="bubble">What did we learn from the Q3 numbers?</div>


### PR DESCRIPTION
Spotted by Snow: the Claude-chat mockup showed the agent minting a public `/s/` link unasked for a "share with the team" prompt — contradicting the shipped default (skill's *Share what you make* rule: gated `bdrive url` viewer link for teammates; `bdrive share` public links only on explicit request). The mockup now shows the gated project URL with sign-in framing and offers the public link as opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5cxPQdSGJnjXCYY9GeWXt