### PR TITLE
chore(plugin): bump plugin version to 0.2.0

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "beardrive",
   "displayName": "BearDrive",
   "description": "BearDrive — the open-source Google Drive for AI agents: mount folders that stay in sync across devices and teammates through a self-hostable BearDrive hub (backed by S3/GCS/any object store), with turn-boundary sync, per-change attribution, and full change history. CLI: bdrive.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "runbear",
     "url": "https://github.com/runbear-io"


### PR DESCRIPTION
Bumps the Claude Code plugin (and its beardrive skill) from 0.1.0 to 0.2.0 to reflect skill updates since the initial release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)