### PR TITLE
chore: gitignore /cloud/ (private beardrive-cloud nested repo)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .DS_Store
 .omc
 /example/
+/cloud/


### PR DESCRIPTION
The managed-cloud codebase lives nested at `cloud/` inside OSS checkouts but is tracked by its own private repository. Ignore it here so the OSS worktree never picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)