### PR TITLE
fix(cli): log/status show signed-in account, not git author fallback

### DIFF
--- a/cmd/bdrive/cmds.go
+++ b/cmd/bdrive/cmds.go
@@ -90,7 +90,15 @@ func statusCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Printf("device: %s (%s) as %s\n\n", dev.Name, dev.ID, dev.Author)
+			if settings, _ := config.LoadSettings(); settings.Email != "" {
+				who := settings.Email
+				if settings.Name != "" {
+					who = settings.Name + " <" + settings.Email + ">"
+				}
+				fmt.Printf("device: %s (%s) signed in as %s\n\n", dev.Name, dev.ID, who)
+			} else {
+				fmt.Printf("device: %s (%s) as %s\n\n", dev.Name, dev.ID, dev.Author)
+			}
 			first := true
 			for id, mi := range mounts {
 				if !first {
@@ -179,7 +187,16 @@ func logCmd() *cobra.Command {
 				} else {
 					kind = "delete"
 				}
-				line := fmt.Sprintf("%s  %s  %-40s  %s on %s", when, kind, op.Path, op.Author, op.DeviceName)
+				// Prefer the signed-in account over the git/OS author fallback,
+				// so team history shows hub identities.
+				who := op.UserName
+				if who == "" {
+					who = op.User
+				}
+				if who == "" {
+					who = op.Author
+				}
+				line := fmt.Sprintf("%s  %s  %-40s  %s on %s", when, kind, op.Path, who, op.DeviceName)
 				if op.Kind == journal.KindPut {
 					line += fmt.Sprintf("  (%s)", humanBytes(op.Size))
 				}


### PR DESCRIPTION
Found by the live agent-onboarding e2e: a device signed in as `e2e-bot@beardrive.dev` showed `snow@runbear.io` (git config author) in `bdrive log`, because the display used `Op.Author` even when `Op.User`/`Op.UserName` carried the hub account.

- `bdrive log`: identity displayed as UserName → User → Author (fallback unchanged for offline/no-auth setups)
- `bdrive status`: header shows `signed in as Name <email>` when a session exists

Verified against real journal data from the e2e hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)