### PR TITLE
fix(sync): anchor --shared include entries to the mount root

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ the project:
 ```jsonc
 // .bdrive/config.json
 { "id": "m-5a10b713", "volume": "notes",
-  "remote": "https://drive.example.com/p/p-7f3a2c91", "include": ["shared/"] }
+  "remote": "https://drive.example.com/p/p-7f3a2c91", "include": ["/shared/"] }
 ```
 
 Opting out is non-destructive: when a pattern starts matching an

--- a/cmd/bdrive/init.go
+++ b/cmd/bdrive/init.go
@@ -274,10 +274,12 @@ func chooseScope() ([]string, error) {
 	return strings.Fields(strings.ReplaceAll(dirs, ",", " ")), nil
 }
 
-// cleanShared normalizes --shared entries into include patterns ("wiki/"):
-// slashes cleaned, duplicates dropped. Any entry that resolves to the mount
-// root or escapes it is an error — a silently-dropped "." would widen the
-// scope to the whole folder.
+// cleanShared normalizes --shared entries into include patterns ("/wiki/"):
+// slashes cleaned, duplicates dropped. The leading slash anchors the pattern
+// to the mount root — without it a nested directory of the same name (say
+// .claude/skills/x/wiki/) would match and sync too. Any entry that resolves
+// to the mount root or escapes it is an error — a silently-dropped "." would
+// widen the scope to the whole folder.
 func cleanShared(shared []string) ([]string, error) {
 	var out []string
 	seen := map[string]bool{}
@@ -288,7 +290,7 @@ func cleanShared(shared []string) ([]string, error) {
 		}
 		if !seen[s] {
 			seen[s] = true
-			out = append(out, s+"/")
+			out = append(out, "/"+s+"/")
 		}
 	}
 	return out, nil

--- a/cmd/bdrive/init_test.go
+++ b/cmd/bdrive/init_test.go
@@ -6,25 +6,28 @@ import (
 )
 
 func TestScopeRemove(t *testing.T) {
-	include := []string{"wiki/", "docs/", "*.md"}
 	for _, tc := range []struct {
-		args []string
-		want []string
-		err  bool
+		include []string
+		args    []string
+		want    []string
+		err     bool
 	}{
-		{args: []string{"docs"}, want: []string{"wiki/", "*.md"}},
-		{args: []string{"docs/"}, want: []string{"wiki/", "*.md"}},   // normalized match
-		{args: []string{"*.md"}, want: []string{"wiki/", "docs/"}},   // literal pattern match
-		{args: []string{"wiki", "docs"}, want: []string{"*.md"}},
-		{args: []string{"notes"}, err: true}, // not in scope
+		{include: []string{"/wiki/", "/docs/", "*.md"}, args: []string{"docs"}, want: []string{"/wiki/", "*.md"}},
+		{include: []string{"/wiki/", "/docs/", "*.md"}, args: []string{"docs/"}, want: []string{"/wiki/", "*.md"}}, // normalized match
+		{include: []string{"/wiki/", "/docs/", "*.md"}, args: []string{"*.md"}, want: []string{"/wiki/", "/docs/"}}, // literal pattern match
+		{include: []string{"/wiki/", "/docs/", "*.md"}, args: []string{"wiki", "docs"}, want: []string{"*.md"}},
+		{include: []string{"/wiki/", "/docs/", "*.md"}, args: []string{"notes"}, err: true}, // not in scope
+		// A config written before include entries were anchored: the
+		// unanchored form must still be removable.
+		{include: []string{"wiki/", "docs/"}, args: []string{"wiki"}, want: []string{"docs/"}},
 	} {
-		got, err := scopeRemove(include, tc.args)
+		got, err := scopeRemove(tc.include, tc.args)
 		if tc.err != (err != nil) {
-			t.Errorf("scopeRemove(%q) err = %v, want err %v", tc.args, err, tc.err)
+			t.Errorf("scopeRemove(%q, %q) err = %v, want err %v", tc.include, tc.args, err, tc.err)
 			continue
 		}
 		if !tc.err && !reflect.DeepEqual(got, tc.want) {
-			t.Errorf("scopeRemove(%q) = %q, want %q", tc.args, got, tc.want)
+			t.Errorf("scopeRemove(%q, %q) = %q, want %q", tc.include, tc.args, got, tc.want)
 		}
 	}
 }
@@ -36,10 +39,10 @@ func TestCleanShared(t *testing.T) {
 		err  bool
 	}{
 		{in: nil, want: nil},
-		{in: []string{"wiki"}, want: []string{"wiki/"}},
-		{in: []string{"wiki", "docs"}, want: []string{"wiki/", "docs/"}},
-		{in: []string{" wiki ", "./docs/", "wiki"}, want: []string{"wiki/", "docs/"}}, // trimmed, cleaned, deduped
-		{in: []string{"a/b"}, want: []string{"a/b/"}},
+		{in: []string{"wiki"}, want: []string{"/wiki/"}}, // anchored: only the root-level wiki/
+		{in: []string{"wiki", "docs"}, want: []string{"/wiki/", "/docs/"}},
+		{in: []string{" wiki ", "./docs/", "wiki"}, want: []string{"/wiki/", "/docs/"}}, // trimmed, cleaned, deduped
+		{in: []string{"a/b"}, want: []string{"/a/b/"}},
 		{in: []string{""}, err: true},
 		{in: []string{"wiki", ""}, err: true}, // "wiki,,docs" typo must not half-apply
 		{in: []string{"."}, err: true},        // would silently mean whole-folder sync

--- a/cmd/bdrive/scope.go
+++ b/cmd/bdrive/scope.go
@@ -128,14 +128,17 @@ func scopeRmCmd() *cobra.Command {
 }
 
 // scopeRemove drops the named dirs from the include list, matching each
-// argument both literally and in normalized "dir/" form (hand-edited
-// configs may hold arbitrary patterns). Unknown entries are an error.
+// argument literally, in normalized "/dir/" form, and in the pre-anchoring
+// "dir/" form that configs written before the anchoring fix still hold
+// (hand-edited configs may hold arbitrary patterns). Unknown entries are an
+// error.
 func scopeRemove(include, args []string) ([]string, error) {
 	remove := map[string]bool{}
 	for _, a := range args {
 		keys := map[string]bool{strings.TrimSpace(a): true}
 		if norm, err := cleanShared([]string{a}); err == nil {
 			keys[norm[0]] = true
+			keys[strings.TrimPrefix(norm[0], "/")] = true
 		}
 		found := false
 		for _, i := range include {
@@ -164,6 +167,6 @@ func printScope(proj config.Project) {
 	}
 	fmt.Println("syncing only:")
 	for _, i := range proj.Include {
-		fmt.Println("  ./" + strings.TrimSuffix(i, "/"))
+		fmt.Println("  ./" + strings.Trim(i, "/"))
 	}
 }

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // ProjectDir is the per-folder settings directory at the mount root. It
@@ -63,7 +64,25 @@ func LoadProject(folder string) (Project, bool, error) {
 	if err := json.Unmarshal(data, &p); err != nil {
 		return p, false, fmt.Errorf("parse %s: %w", projectConfigPath(folder), err)
 	}
+	p.Include = normalizeInclude(p.Include)
 	return p, true, nil
+}
+
+// normalizeInclude anchors bare single-segment include entries to the mount
+// root, so a config written before the fix ("wiki/") stops matching nested
+// directories of the same name without needing a re-init. Only single-segment
+// entries need it: compile() already anchors anything containing a slash.
+// Entries with glob syntax are left alone — a hand-written pattern is a
+// deliberate pattern.
+func normalizeInclude(include []string) []string {
+	for n, i := range include {
+		s := strings.TrimSuffix(i, "/")
+		if s == "" || strings.ContainsAny(s, "/*?[!") {
+			continue
+		}
+		include[n] = "/" + i
+	}
+	return include
 }
 
 // SaveProject writes <folder>/.bdrive/config.json, assigning a mount ID on

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalizeInclude(t *testing.T) {
+	for _, tc := range []struct {
+		in   []string
+		want []string
+	}{
+		{in: nil, want: nil},
+		{in: []string{"wiki/"}, want: []string{"/wiki/"}}, // legacy config, anchored on read
+		{in: []string{"wiki"}, want: []string{"/wiki"}},
+		{in: []string{"/wiki/"}, want: []string{"/wiki/"}}, // already anchored
+		{in: []string{"a/b/"}, want: []string{"a/b/"}},     // compile() anchors these already
+		{in: []string{"*.md"}, want: []string{"*.md"}},     // deliberate pattern, left alone
+		{in: []string{"!keep"}, want: []string{"!keep"}},
+		{in: []string{"wiki/", "*.md"}, want: []string{"/wiki/", "*.md"}},
+	} {
+		in := append([]string(nil), tc.in...)
+		if got := normalizeInclude(tc.in); !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("normalizeInclude(%q) = %q, want %q", in, got, tc.want)
+		}
+	}
+}

--- a/internal/syncer/filter_sync_test.go
+++ b/internal/syncer/filter_sync_test.go
@@ -76,3 +76,29 @@ func TestIncludeListLimitsSync(t *testing.T) {
 		}
 	}
 }
+
+// The shared-subfolder scope is anchored at the mount root: a nested
+// directory that happens to share the name must never sync, or private
+// material leaks out of a project scoped to one folder.
+func TestIncludeListIsRootAnchored(t *testing.T) {
+	for _, include := range []string{"/shared/", "shared/"} { // new form, and pre-fix configs
+		t.Run(include, func(t *testing.T) {
+			be := sharedRemote(t)
+			a := newDevice(t, "deva", be)
+			b := newDevice(t, "devb", be)
+
+			write(t, a.Folder, ".bdrive/config.json", `{"include": ["`+include+`"]}`)
+			write(t, a.Folder, "shared/a.txt", "included")
+			write(t, a.Folder, ".claude/skills/x/shared/leak.mjs", "private")
+			cycle(t, a)
+			cycle(t, b)
+
+			if got := read(t, b.Folder, "shared/a.txt"); got != "included" {
+				t.Fatalf("shared/a.txt = %q", got)
+			}
+			if _, err := os.Stat(filepath.Join(b.Folder, ".claude/skills/x/shared/leak.mjs")); !os.IsNotExist(err) {
+				t.Fatal("a nested dir named shared/ must not sync")
+			}
+		})
+	}
+}

--- a/plugin/skills/beardrive/SKILL.md
+++ b/plugin/skills/beardrive/SKILL.md
@@ -48,7 +48,7 @@ Two files at the mount root control a folder's sync behavior:
   "id": "m-5a10b713",
   "volume": "agent-workspace",
   "remote": "https://drive.example.com/p/p-7f3a2c91",
-  "include": ["shared/"]   // optional: sync ONLY these (init --shared; edit with bdrive scope add/rm)
+  "include": ["/shared/"]  // optional: sync ONLY these (init --shared; edit with bdrive scope add/rm)
 }
 ```
 

--- a/web/docs/src/content/docs/guides/scoping.md
+++ b/web/docs/src/content/docs/guides/scoping.md
@@ -29,8 +29,12 @@ The result lands in `.bdrive/config.json` as an include list:
 
 ```jsonc
 { "id": "m-5a10b713", "volume": "notes",
-  "remote": "https://drive.example.com/p/p-7f3a2c91", "include": ["wiki/"] }
+  "remote": "https://drive.example.com/p/p-7f3a2c91", "include": ["/wiki/"] }
 ```
+
+The leading slash anchors each entry to the mount root: `/wiki/` means the
+`wiki` folder at the top of this project and nothing else, so a nested
+directory that happens to share the name never syncs.
 
 ## Change the scope later
 

--- a/web/docs/src/content/docs/reference/project-files.md
+++ b/web/docs/src/content/docs/reference/project-files.md
@@ -14,7 +14,7 @@ plus project, remote, and include settings.
 ```jsonc
 // .bdrive/config.json
 { "id": "m-5a10b713", "volume": "notes",
-  "remote": "https://drive.example.com/p/p-7f3a2c91", "include": ["shared/"] }
+  "remote": "https://drive.example.com/p/p-7f3a2c91", "include": ["/shared/"] }
 ```
 
 Written by `bdrive init` and safe to hand-edit — a running daemon picks changes


### PR DESCRIPTION
## TL;DR

* `bdrive init --shared wiki` was quietly syncing *every* nested folder named `wiki`, not just the one you picked — real projects leaked files from `.claude/`, `.agents/` and `.gemini/`.
* Fix is one character-ish: include entries are now anchored (`/wiki/`), which covers both `init --shared` and `bdrive scope add`.
* Existing projects are fixed on read — no re-init, no config rewrite, daemon narrows the scope within seconds of upgrading.
* Known gap: the files already on the hub stay there. Removing them is [BEA-20](https://linear.app/runbear/issue/BEA-20), and emitting a delete op here would unlink teammates' local copies.

Closes [BEA-5](https://linear.app/runbear/issue/BEA-5/shared-subfolder-include-filter-matches-nested-dirs-named-shared)

## The bug

`cleanShared` ([cmd/bdrive/init.go:283](cmd/bdrive/init.go)) emitted `wiki/`. `compile()` derives `anchored` from a leading `/` **after** trimming slashes ([internal/syncer/ignore.go:106-113](internal/syncer/ignore.go)), so a single-segment entry can never anchor:

```
"wiki"    no "/"        -> anchored=false -> (^|.*/)wiki/.*$     <- the bug
"a/b"     contains "/"  -> anchored=true  -> ^a/b/.*$            <- already fine
"/wiki/"  leading "/"   -> anchored=true  -> ^wiki/.*$           <- the fix
```

Only single-segment entries were ever broken — which is why the migration rule below is narrower than "any non-glob entry".

## What changed

1. **`cleanShared` emits `/wiki/`** — one line, and both callers (`init --shared` and `scope add`) inherit it. The `MkdirAll` callers are safe: `filepath.Join(folder, "/wiki")` cleans the leading slash.
2. **`config.LoadProject` anchors legacy entries on read** (`normalizeInclude`) — a bare single-segment entry with no glob syntax (`*?[!`) gets the `/`. Everything reading `Include` (sync cycle, daemon, `scope`, `url`, `read-log`) goes through `LoadProject`, so one place fixes all of them.
3. **`scope rm` still matches the unanchored form.** Step 2 already handles it, but `scopeRemove` also tries the bare `wiki/` key so a hand-edited config or a path bypassing `LoadProject` still resolves — otherwise `bdrive scope rm wiki` would fail on every pre-fix project.
4. **`printScope`** trims both slashes so an anchored entry prints `./wiki`, not `.//wiki`.
5. Docs: README, `SKILL.md`, `reference/project-files.md`, `guides/scoping.md`.

Deliberately unchanged: `compile()` itself, `.bdriveignore` semantics (user patterns stay gitignore-style, unanchored), and the deferred `sharedRoot` config field.

## Verification

* `go build ./...`, `go vet ./...`, `go test ./...` — all pass.
* **New multi-device syncer test** `TestIncludeListIsRootAnchored` ([internal/syncer/filter_sync_test.go](internal/syncer/filter_sync_test.go)), run for both the new and legacy config forms: `shared/a.txt` reaches device B, `.claude/skills/x/shared/leak.mjs` does not. Confirmed it **fails** with the migration removed — this is the test the bug would have caught.
* `TestNormalizeInclude` (new), `TestCleanShared` and `TestScopeRemove` (updated, with a legacy-config removal case).
* Manual CLI run against a hand-written legacy config (`include: ["wiki/"]`): `bdrive scope` prints `./wiki`, `scope add docs` writes `["/wiki/", "/docs/"]`, `scope rm wiki` succeeds.

No frontend or webapp change, so no `npm run build`, e2e, or UI pass — nothing under `internal/webapp` is touched. No architecture diagram change: `Project`'s drawn field set is unchanged and `normalizeInclude` is an unexported helper.

## Build session

```
cd $(git worktree list | grep bea-5-shared-subfolder | awk '{print $1}') && claude --resume 830381db-43ad-4d1f-b033-baa953df5a15
```

(Only works on the machine the build ran on.)