### PR TITLE
fix(daemon): let the daemon own its pidfile, so stop can stop it

### DIFF
--- a/architecture/cli-sync.md
+++ b/architecture/cli-sync.md
@@ -184,7 +184,7 @@ classDiagram
         volumes/id/daemon.lock
         volumes/id/daemon.pid
     }
-    note for DaemonLock "internal/daemon — liveness is the flock, held for the daemon's lifetime; the kernel drops it at death/reboot, so a leftover pid can never read as running (pid is display + signal only)"
+    note for DaemonLock "internal/daemon — liveness is the flock, held for the daemon's lifetime; the kernel drops it at death/reboot, so a leftover pid can never read as running (pid is display + signal only). The daemon writes daemon.pid ITSELF, after taking the lock, and removes it on exit: only the lock holder may name itself there, or Stop signals a pid that lost the start race. Start writes no pid — it waits for the lock, so a returned pid always has a daemon behind it"
 
     Commands --> Autostart : autostart install/uninstall (init runs install automatically)
     Autostart ..> Commands : login runs `bdrive resume`

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -124,12 +124,38 @@ func Start(folder, volDir string, scanInterval, remoteInterval time.Duration) (i
 	if err := cmd.Start(); err != nil {
 		return 0, err
 	}
-	pid := cmd.Process.Pid
-	if err := os.WriteFile(PidPath(volDir), []byte(strconv.Itoa(pid)+"\n"), 0o644); err != nil {
-		return pid, err
+	if err := cmd.Process.Release(); err != nil {
+		return 0, err
 	}
-	return pid, cmd.Process.Release()
+
+	// The child announces its own pid, and only once it holds the lifetime
+	// lock (see Run). The parent must NOT write PidPath: a child that loses
+	// the lock race exits without ever being the daemon, and its pid written
+	// here would outlive it — leaving Stop signalling a corpse (ESRCH) while
+	// the daemon that won keeps syncing, and status printing a phantom pid.
+	//
+	// So wait for the lock instead of assuming the spawn worked. A caller
+	// that gets a pid back can trust that a daemon owns it. In a race the pid
+	// is the winner's rather than the child just spawned, which is the honest
+	// answer to "which pid is the daemon" — callers that need to distinguish
+	// starting from adopting check Running first (see `bdrive resume`).
+	deadline := time.Now().Add(startTimeout)
+	for {
+		if pid, ok := Running(volDir); ok && pid > 0 {
+			return pid, nil
+		}
+		if time.Now().After(deadline) {
+			return 0, fmt.Errorf("daemon did not come up within %s; see %s",
+				startTimeout, LogPath(volDir))
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 }
+
+// startTimeout bounds how long Start waits for the child to take the lock and
+// write its pid. Generous on purpose: it covers a cold binary on a loaded
+// machine, and the only cost of waiting is a slower `bdrive init`.
+const startTimeout = 10 * time.Second
 
 // Stop terminates the daemon for a mount and waits for it to exit. Exit is
 // observed by the lock being released, not by the pid disappearing: the pid

--- a/internal/webapp/cli_daemon_race_test.go
+++ b/internal/webapp/cli_daemon_race_test.go
@@ -1,0 +1,104 @@
+package webapp
+
+// Regression: two daemon starts close together must not leave daemon.pid
+// naming a process that is not the one holding the lock.
+//
+// Liveness is the flock (see internal/daemon.LockPath), but Start() writes
+// daemon.pid from the PARENT, with the pid of a child that has not taken the
+// lock yet. The realistic collision is `bdrive init` immediately followed by
+// the login agent's `bdrive resume`: Running() still reads false, so resume
+// starts a second daemon, the loser exits, and its pid is already in the file.
+//
+// The damage is not cosmetic. `bdrive stop` signals the pid from that file, so
+// it fails with ESRCH while the surviving daemon keeps syncing — sync cannot be
+// turned off, and `stop` is consent withdrawal. `bdrive status` also prints the
+// phantom pid.
+//
+// TestCLIOnboardingE2E already asserts `resume` reports "already running 1",
+// but only after several intervening assertions have given the child time to
+// lock. This test deliberately runs resume with no delay, which is the window a
+// real login agent can land in.
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestCLIDaemonPidFileNamesTheLockHolder(t *testing.T) {
+	e := newCLIEnv(t)
+	work := t.TempDir()
+
+	if out, err := e.run(work, "init", "--name", "race-e2e", "--yes"); err != nil {
+		t.Fatalf("init: %v\n%s", err, out)
+	}
+
+	// No sleep on purpose: the absence of one IS the test.
+	resumeOut, err := e.run(work, "resume")
+	if err != nil {
+		t.Fatalf("resume: %v\n%s", err, resumeOut)
+	}
+
+	pidPath := findDaemonPidFile(t, filepath.Join(e.home, ".bdrive", "volumes"))
+	pid := readDaemonPid(t, pidPath)
+	t.Cleanup(func() { syscall.Kill(pid, syscall.SIGTERM) })
+
+	// resume must recognise the daemon init just started rather than race it.
+	if !strings.Contains(resumeOut, "already running 1") {
+		t.Errorf("resume did not see the daemon init started, so it started another:\n%s", resumeOut)
+	}
+
+	// Whatever daemon.pid names must actually exist: stop and status both
+	// trust it, and after a reboot it is all that identifies the daemon.
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Errorf("daemon.pid names pid %d, which is not running (%v) — stop and status both trust this file", pid, err)
+	}
+
+	// The consequence, asserted directly: stop must work and must leave
+	// nothing syncing behind it.
+	out, err := e.run(work, "stop")
+	if err != nil {
+		t.Errorf("stop failed while a daemon was running: %v\n%s", err, out)
+	}
+	if out, err := e.run(work, "status"); err == nil && strings.Contains(out, "daemon:   running") {
+		t.Errorf("a daemon is still running after stop:\n%s", out)
+	}
+}
+
+// findDaemonPidFile returns the single daemon.pid under root, failing if there
+// is not exactly one — more than one would mean the test mounted more than it
+// meant to, and the assertions below would be about the wrong daemon.
+func findDaemonPidFile(t *testing.T, root string) string {
+	t.Helper()
+	var found []string
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("no volume dir at %s: %v", root, err)
+	}
+	for _, e := range entries {
+		p := filepath.Join(root, e.Name(), "daemon.pid")
+		if _, err := os.Stat(p); err == nil {
+			found = append(found, p)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("want exactly one daemon.pid under %s, found %d: %v", root, len(found), found)
+	}
+	return found[0]
+}
+
+func readDaemonPid(t *testing.T, path string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		t.Fatalf("%s does not hold a pid: %q", path, data)
+	}
+	return pid
+}


### PR DESCRIPTION
## TL;DR

- `bdrive stop` could fail with `Error: no such process` and leave sync running — the one command whose job is to stop sending your files.
- `bdrive status` could print a pid that doesn't exist, or `pid 0`.
- Cause: `Start` wrote `daemon.pid` from the parent for a child that hadn't taken the lock yet, so a losing racer's pid ended up in the file.
- Fix is a deletion: the daemon already writes its own pid after `hold()`, so the parent stops writing one and waits for the lock instead.
- Ships a regression test — deterministic on Linux, ~1 run in 5 on macOS, so treat CI as the guard.

## What went wrong

#88 made liveness the flock, and `Run` was already correct: take the lock, *then* announce your own pid, remove it on exit. But `Start` still did this right after fork:

```go
pid := cmd.Process.Pid
if err := os.WriteFile(PidPath(volDir), ...); err != nil {   // ← for a child that owns nothing yet
```

Two starts inside the window before the child locks — `bdrive init` followed by the login agent's `bdrive resume`, or two resumes close together — race. `Running` still reads false, a second child spawns, loses `hold()`, and exits without ever being the daemon. Its pid is already in the file.

Everything downstream trusts that file:

- `Stop` signals the loser, gets `ESRCH`, reports failure — while the winner keeps syncing.
- `status` prints the phantom pid, or `pid 0` when `Running` finds the lock held with no readable pid.
- `resume` printed `started (pid N)` for a process that had already died.

Reproduced in the sandbox against merged main:

```
daemon.pid says 140; actually alive: 123
FAIL  daemon.pid names 140, which is not running
FAIL  stop failed: Error: no such process
FAIL  stop left daemon(s) running: 123 — sync cannot be turned off
```

## The change

`Start` no longer writes `PidPath` at all — the pidfile belongs to whoever holds the lock. Instead it polls `Running` until a lock holder with a readable pid appears, or errors after 10s pointing at `daemon.log`. So a caller that gets a pid back can trust a daemon owns it.

In a race the returned pid is the winner's rather than the child just spawned, which is the honest answer to "which pid is the daemon". Callers that need to tell starting from adopting already check `Running` first — `bdrive resume` does.

`Stop`, `Running`, and every caller are untouched.

## Testing

- `go test ./...` green, all 10 packages; `go vet` clean.
- New `TestCLIDaemonPidFileNamesTheLockHolder` run 8× consecutively — one pass proves nothing on a timing bug.
- `sandbox/run.sh daemon-linux` went 3 failures → 0 on the same code path.

It lives with the CLI e2e rather than in `internal/daemon`, because reproducing needs the real binary (`Start` execs `os.Executable`) and that package's tests synthesize locks instead of spawning daemons. Nothing on main spawned two racing starts, which is why this shipped.

**Known gap:** the test is timing-dependent — deterministic on Linux, roughly 1 run in 5 on macOS where the window is tighter. It's a CI ratchet, not a local signal. The reliable reproducer is the sandbox scenario, which is a separate uncommitted change.

Also considered and rejected: making `Stop` wait for the pid when the lock is held with none readable. That window is microseconds, and waiting made the genuinely-broken case (which `TestLockedWithoutPidFile` covers) block for the full timeout — `internal/daemon` went from 0.76s to 10.8s. Trading a 10-second hang on a real fault for a cosmetic race is the wrong way round.

## Architecture changes

`architecture/cli-sync.md` — the `DaemonLock` note documents the lock/pid contract but not who writes the pid. That ownership moved from `Start` to the daemon itself, so the note now says so.

**Before**

```mermaid
classDiagram
    class DaemonLock {
        volumes/id/daemon.lock
        volumes/id/daemon.pid
    }
    note for DaemonLock "internal/daemon — liveness is the flock, held for the daemon's lifetime; the kernel drops it at death/reboot, so a leftover pid can never read as running (pid is display + signal only)"
    Commands --> DaemonLock : Running / Start / Stop
```

**After**

```mermaid
classDiagram
    class DaemonLock {
        volumes/id/daemon.lock
        volumes/id/daemon.pid
    }
    note for DaemonLock "internal/daemon — liveness is the flock, held for the daemon's lifetime; the kernel drops it at death/reboot, so a leftover pid can never read as running (pid is display + signal only). The daemon writes daemon.pid ITSELF, after taking the lock, and removes it on exit: only the lock holder may name itself there, or Stop signals a pid that lost the start race. Start writes no pid — it waits for the lock, so a returned pid always has a daemon behind it"
    Commands --> DaemonLock : Running / Start / Stop
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgF8JsoeNPVShGYWdooE72