### PR TITLE
feat(auth): the browser sign-in says whose account the terminal gets

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ hub's own storage, never something a syncing client points at directly:
 
 | Command | Description |
 |---|---|
-| `bdrive login [server-url]` | Sign this device in (browser flow; `--device` forces the approval-link flow, and shells without a TTY fall back to it automatically; default server beardrive.ai — the managed cloud, free personal workspace on signup; pass your hub URL to self-host). Switch hubs with `bdrive login <new-url>` |
+| `bdrive login [server-url]` | Sign this device in (browser flow — the page names the account this terminal would act as and lets you switch before approving; `--device` forces the approval-link flow, and shells without a TTY fall back to it automatically; default server beardrive.ai — the managed cloud, free personal workspace on signup; pass your hub URL to self-host). Switch hubs with `bdrive login <new-url>` |
 | `bdrive logout` | Sign this device out — clear the saved token/account (`--forget` also drops the remembered server) |
 | `bdrive init [folder]` | Create/connect a project and start syncing — the mount is always exactly the folder named. Interactive on a TTY, flags (`--name/--project/--server/--only/--yes`) for scripts; registers agent sync hooks and the login autostart in each platform's user config (`--no-hooks` skips the hooks), prints the project link; re-run to resume |
 | `bdrive resume` | Restart the sync daemon for every project on this device that isn't paused — after a reboot, a crash, or a manual kill. Idempotent; this is what the login agent runs |

--- a/cmd/bdrive/login.go
+++ b/cmd/bdrive/login.go
@@ -297,7 +297,7 @@ func browserLogin(server, loginPath string) (string, serverUser, error) {
 		// a URL the user pastes elsewhere would dead-end — use the code flow.
 		return "", serverUser{}, errNoBrowser
 	}
-	fmt.Println("waiting for the browser sign-in… (no browser here? Ctrl-C and run `bdrive login --device`)")
+	fmt.Println("waiting for you to approve the sign-in in your browser… (no browser here? Ctrl-C and run `bdrive login --device`)")
 
 	select {
 	case code := <-codeCh:

--- a/internal/syncer/org_authz_test.go
+++ b/internal/syncer/org_authz_test.go
@@ -87,7 +87,9 @@ func signupDeviceToken(t *testing.T, ts *httptest.Server, email, name string) st
 		t.Fatalf("signup(%s) set no session cookie: %d", email, resp.StatusCode)
 	}
 
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/cli?redirect="+url.QueryEscape("http://127.0.0.1:1/cb")+"&state=s", nil)
+	// POST, not GET: /auth/cli shows a confirmation page first, and approving
+	// it is what mints the code — the same click a user makes in the browser.
+	req, _ := http.NewRequest("POST", ts.URL+"/auth/cli?redirect="+url.QueryEscape("http://127.0.0.1:1/cb")+"&state=s", nil)
 	req.AddCookie(session)
 	resp, err = jarless.Do(req)
 	if err != nil {

--- a/internal/webapp/auth_test.go
+++ b/internal/webapp/auth_test.go
@@ -3,11 +3,13 @@ package webapp
 import (
 	"context"
 	"encoding/json"
+	"html"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -223,8 +225,24 @@ func TestCLICallbackFlow(t *testing.T) {
 		t.Fatalf("cli without session: %d %s", rec.Code, rec.Header().Get("Location"))
 	}
 
-	// with a session: redirect back to the loopback with code+state
-	req = httptest.NewRequest("GET", "/auth/cli?redirect="+url.QueryEscape("http://127.0.0.1:9999/callback")+"&state=s1", nil)
+	// with a session, a GET asks first — it names the account the terminal
+	// would act as and offers to switch, and grants nothing on its own.
+	cliURL := "/auth/cli?redirect=" + url.QueryEscape("http://127.0.0.1:9999/callback") + "&state=s1"
+	req = httptest.NewRequest("GET", cliURL, nil)
+	req.AddCookie(cookie)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("cli confirmation page: %d, want 200", rec.Code)
+	}
+	for _, want := range []string{"cli@x.io", "Switch account", "127.0.0.1:9999", "Approve"} {
+		if !strings.Contains(rec.Body.String(), want) {
+			t.Fatalf("confirmation page missing %q:\n%s", want, rec.Body)
+		}
+	}
+
+	// approving posts back to the same URL and lands on the loopback listener
+	req = httptest.NewRequest("POST", cliURL, nil)
 	req.AddCookie(cookie)
 	rec = httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -567,5 +585,67 @@ func TestConfigAnalyticsSeam(t *testing.T) {
 	srv.Analytics.Host = "https://eu.i.posthog.com"
 	if got := string(config(srv)["analytics"]); got != `{"host":"https://eu.i.posthog.com","key":"phc_test"}` {
 		t.Fatalf("analytics host override = %s", got)
+	}
+}
+
+// The reason the CLI flow confirms at all: the browser's session is often not
+// the account the user meant the terminal to act as. Switching must come back
+// to the same pending sign-in rather than dumping them on the home page.
+func TestCLILoginSwitchAccount(t *testing.T) {
+	srv, _, _ := authHub(t, true)
+	h := srv.Handler()
+	personal := signupAndSession(t, h, "me@personal.io", "Me", "password1")
+
+	cliURL := "/auth/cli?redirect=" + url.QueryEscape("http://127.0.0.1:9999/callback") + "&state=s1"
+
+	// the page offers a way out, carrying this sign-in along
+	req := httptest.NewRequest("GET", cliURL, nil)
+	req.AddCookie(personal)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	swap := regexp.MustCompile(`href="(/auth/logout\?next=[^"]+)"`).FindStringSubmatch(rec.Body.String())
+	if swap == nil {
+		t.Fatalf("no switch-account link on the confirmation page:\n%s", rec.Body)
+	}
+
+	// following it drops the session and heads for a fresh login
+	req = httptest.NewRequest("GET", html.UnescapeString(swap[1]), nil)
+	req.AddCookie(personal)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	loc := rec.Header().Get("Location")
+	if rec.Code != http.StatusSeeOther || !strings.HasPrefix(loc, "/auth/login?next=") {
+		t.Fatalf("switch account = %d %s", rec.Code, loc)
+	}
+	next, err := url.QueryUnescape(strings.TrimPrefix(loc, "/auth/login?next="))
+	if err != nil || next != cliURL {
+		t.Fatalf("switch account loses the pending sign-in: next=%q want %q", next, cliURL)
+	}
+
+	// signing in as someone else returns to the same confirmation, now naming them
+	work := signupAndSession(t, h, "me@work.io", "Me At Work", "password2")
+	req = httptest.NewRequest("GET", next, nil)
+	req.AddCookie(work)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "me@work.io") {
+		t.Fatalf("after switching, confirmation does not name the new account: %d\n%s", rec.Code, rec.Body)
+	}
+	if strings.Contains(rec.Body.String(), "me@personal.io") {
+		t.Fatalf("confirmation still shows the old account:\n%s", rec.Body)
+	}
+
+	// and approving as them grants to them
+	req = httptest.NewRequest("POST", next, nil)
+	req.AddCookie(work)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("approve after switch: %d", rec.Code)
+	}
+	cb, _ := url.Parse(rec.Header().Get("Location"))
+	out := do(t, h, "POST", "/api/auth/exchange", map[string]string{"code": cb.Query().Get("code"), "device": "laptop"})
+	if !strings.Contains(out.Body.String(), "me@work.io") {
+		t.Fatalf("token issued to the wrong account: %s", out.Body)
 	}
 }

--- a/internal/webapp/auth_test.go
+++ b/internal/webapp/auth_test.go
@@ -650,78 +650,81 @@ func TestCLILoginSwitchAccount(t *testing.T) {
 	}
 }
 
-// A first `bdrive init` on a fresh machine must cost ONE web step, not two.
-// Signing in for this very sign-in is the consent, so the confirmation page is
-// skipped — but only for that sign-in, and only once.
-func TestCLILoginFirstTimeIsOneStep(t *testing.T) {
-	srv, _, _ := authHub(t, true)
+// Both sign-in flows must behave identically for someone with no web session:
+// sign in, then explicitly approve. Nothing may shortcut the approval — that
+// page is where the user sees which account a machine is about to act as.
+func TestBothFlowsAlwaysAskToApprove(t *testing.T) {
+	srv, auth, _ := authHub(t, true)
 	h := srv.Handler()
 	signupAndSession(t, h, "first@x.io", "First", "password1")
 
-	cliURL := "/auth/cli?redirect=" + url.QueryEscape("http://127.0.0.1:9999/callback") + "&state=s1"
-
-	// no session: the CLI sign-in sends them to log in, saying what it is for
-	req := httptest.NewRequest("GET", cliURL, nil)
-	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
-	loginURL := rec.Header().Get("Location")
-	if rec.Code != http.StatusSeeOther || !strings.HasPrefix(loginURL, "/auth/login?next=") {
-		t.Fatalf("cli without session = %d %s", rec.Code, loginURL)
-	}
-	req = httptest.NewRequest("GET", loginURL, nil)
-	rec = httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
-	if !strings.Contains(rec.Body.String(), "A terminal on this computer is waiting to sign in") {
-		t.Fatalf("login page does not say what it is authorizing:\n%s", rec.Body)
+	// a pending device request, so both flows have something real to approve
+	rec := do(t, h, "POST", "/api/auth/device/start", map[string]string{"device": "laptop", "os": "linux"})
+	var start struct{ Code string }
+	if err := json.Unmarshal(rec.Body.Bytes(), &start); err != nil || start.Code == "" {
+		t.Fatalf("device start: %s", rec.Body)
 	}
 
-	// logging in lands straight on the loopback listener — no second page
-	form := url.Values{"email": {"first@x.io"}, "password": {"password1"}, "next": {cliURL}}
-	req = httptest.NewRequest("POST", loginURL, strings.NewReader(form.Encode()))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	rec = httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
-	if rec.Code != http.StatusSeeOther {
-		t.Fatalf("login: %d %s", rec.Code, rec.Body)
-	}
-	var session *http.Cookie
-	for _, c := range rec.Result().Cookies() {
-		if c.Name == sessionCookie {
-			session = c
-		}
-	}
-	if session == nil {
-		t.Fatal("login started no session")
-	}
+	for _, tc := range []struct{ name, url string }{
+		{"cli", "/auth/cli?redirect=" + url.QueryEscape("http://127.0.0.1:9999/callback") + "&state=s1"},
+		{"device", "/auth/device/" + start.Code},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// no session: sent to sign in, carrying this request
+			req := httptest.NewRequest("GET", tc.url, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			loginURL := rec.Header().Get("Location")
+			if rec.Code != http.StatusSeeOther || !strings.HasPrefix(loginURL, "/auth/login?next=") {
+				t.Fatalf("without a session = %d %s", rec.Code, loginURL)
+			}
 
-	req = httptest.NewRequest("GET", rec.Header().Get("Location"), nil)
-	req.AddCookie(session)
-	rec = httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
-	if rec.Code != http.StatusSeeOther {
-		t.Fatalf("fresh sign-in should grant without asking again: %d\n%s", rec.Code, rec.Body)
-	}
-	cb, _ := url.Parse(rec.Header().Get("Location"))
-	if cb.Host != "127.0.0.1:9999" || cb.Query().Get("code") == "" {
-		t.Fatalf("no code delivered to the listener: %s", rec.Header().Get("Location"))
-	}
+			// signing in returns to the request and must NOT grant on the way
+			form := url.Values{"email": {"first@x.io"}, "password": {"password1"}, "next": {tc.url}}
+			req = httptest.NewRequest("POST", loginURL, strings.NewReader(form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			rec = httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != http.StatusSeeOther || rec.Header().Get("Location") != tc.url {
+				t.Fatalf("login should return to the pending request: %d %s", rec.Code, rec.Header().Get("Location"))
+			}
+			var session *http.Cookie
+			for _, c := range rec.Result().Cookies() {
+				if c.Name == sessionCookie {
+					session = c
+				}
+			}
+			if session == nil {
+				t.Fatal("login started no session")
+			}
 
-	// the skip is spent: the same session visiting again must be asked
-	req = httptest.NewRequest("GET", cliURL, nil)
-	req.AddCookie(session)
-	rec = httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "Approve") {
-		t.Fatalf("a second sign-in must ask: %d\n%s", rec.Code, rec.Body)
-	}
+			// and there the approval page waits — every time, for both flows
+			req = httptest.NewRequest("GET", tc.url, nil)
+			req.AddCookie(session)
+			rec = httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("signing in must not shortcut the approval: %d %s", rec.Code, rec.Header().Get("Location"))
+			}
+			for _, want := range []string{"first@x.io", "Switch account", "Approve"} {
+				if !strings.Contains(rec.Body.String(), want) {
+					t.Fatalf("approval page missing %q:\n%s", want, rec.Body)
+				}
+			}
 
-	// and it never applied to a different pending sign-in
-	other := "/auth/cli?redirect=" + url.QueryEscape("http://127.0.0.1:7777/callback") + "&state=s2"
-	req = httptest.NewRequest("GET", other, nil)
-	req.AddCookie(session)
-	rec = httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("a different sign-in must ask: %d", rec.Code)
+			// only the POST grants
+			req = httptest.NewRequest("POST", tc.url, nil)
+			req.AddCookie(session)
+			rec = httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if tc.name == "cli" {
+				if rec.Code != http.StatusSeeOther {
+					t.Fatalf("approve: %d", rec.Code)
+				}
+			} else if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "Device connected") {
+				t.Fatalf("approve: %d\n%s", rec.Code, rec.Body)
+			}
+		})
 	}
+	_ = auth
 }

--- a/internal/webapp/auth_test.go
+++ b/internal/webapp/auth_test.go
@@ -649,3 +649,79 @@ func TestCLILoginSwitchAccount(t *testing.T) {
 		t.Fatalf("token issued to the wrong account: %s", out.Body)
 	}
 }
+
+// A first `bdrive init` on a fresh machine must cost ONE web step, not two.
+// Signing in for this very sign-in is the consent, so the confirmation page is
+// skipped — but only for that sign-in, and only once.
+func TestCLILoginFirstTimeIsOneStep(t *testing.T) {
+	srv, _, _ := authHub(t, true)
+	h := srv.Handler()
+	signupAndSession(t, h, "first@x.io", "First", "password1")
+
+	cliURL := "/auth/cli?redirect=" + url.QueryEscape("http://127.0.0.1:9999/callback") + "&state=s1"
+
+	// no session: the CLI sign-in sends them to log in, saying what it is for
+	req := httptest.NewRequest("GET", cliURL, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	loginURL := rec.Header().Get("Location")
+	if rec.Code != http.StatusSeeOther || !strings.HasPrefix(loginURL, "/auth/login?next=") {
+		t.Fatalf("cli without session = %d %s", rec.Code, loginURL)
+	}
+	req = httptest.NewRequest("GET", loginURL, nil)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if !strings.Contains(rec.Body.String(), "A terminal on this computer is waiting to sign in") {
+		t.Fatalf("login page does not say what it is authorizing:\n%s", rec.Body)
+	}
+
+	// logging in lands straight on the loopback listener — no second page
+	form := url.Values{"email": {"first@x.io"}, "password": {"password1"}, "next": {cliURL}}
+	req = httptest.NewRequest("POST", loginURL, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("login: %d %s", rec.Code, rec.Body)
+	}
+	var session *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == sessionCookie {
+			session = c
+		}
+	}
+	if session == nil {
+		t.Fatal("login started no session")
+	}
+
+	req = httptest.NewRequest("GET", rec.Header().Get("Location"), nil)
+	req.AddCookie(session)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("fresh sign-in should grant without asking again: %d\n%s", rec.Code, rec.Body)
+	}
+	cb, _ := url.Parse(rec.Header().Get("Location"))
+	if cb.Host != "127.0.0.1:9999" || cb.Query().Get("code") == "" {
+		t.Fatalf("no code delivered to the listener: %s", rec.Header().Get("Location"))
+	}
+
+	// the skip is spent: the same session visiting again must be asked
+	req = httptest.NewRequest("GET", cliURL, nil)
+	req.AddCookie(session)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "Approve") {
+		t.Fatalf("a second sign-in must ask: %d\n%s", rec.Code, rec.Body)
+	}
+
+	// and it never applied to a different pending sign-in
+	other := "/auth/cli?redirect=" + url.QueryEscape("http://127.0.0.1:7777/callback") + "&state=s2"
+	req = httptest.NewRequest("GET", other, nil)
+	req.AddCookie(session)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("a different sign-in must ask: %d", rec.Code)
+	}
+}

--- a/internal/webapp/authlocal.go
+++ b/internal/webapp/authlocal.go
@@ -911,7 +911,7 @@ func (a *BuiltinAuth) pageCLI(w http.ResponseWriter, r *http.Request) {
 			`<p class="lede">A terminal on this computer is asking to sign in to BearDrive.</p>
 %s%s
 <form method="post"><button>Approve</button></form>
-<p class="alt">Approve this only if you just ran <code>bdrive login</code> yourself.</p>`,
+<p class="alt">Approve this only if you just ran <code style="white-space:nowrap">bdrive login</code> yourself.</p>`,
 			whoBlock(user, r.URL.RequestURI()),
 			rows([2]string{"Application", "bdrive command line"}, [2]string{"Waiting at", u.Host})))
 		return

--- a/internal/webapp/authlocal.go
+++ b/internal/webapp/authlocal.go
@@ -50,11 +50,6 @@ type BuiltinAuth struct {
 	// Ephemeral single-use state; a server restart just cancels pending
 	// logins and resets.
 	pending map[string]pendingGrant // auth codes, device codes, reset tokens
-
-	// fresh records that an account authenticated *for a specific pending
-	// sign-in*, so that sign-in doesn't ask again. Keyed by user id + the exact
-	// next URL, single use, short lived. See markFreshAuth.
-	fresh map[string]time.Time
 }
 
 type authUser struct {
@@ -101,7 +96,6 @@ func NewBuiltinAuth(store AccountRepo, allowSignup bool, mail *Mailer) (*Builtin
 		users:   make(map[string]*authUser),
 		tokens:  make(map[string]authToken),
 		pending: make(map[string]pendingGrant),
-		fresh:   make(map[string]time.Time),
 	}
 	users, tokens, policy, err := store.Load()
 	if err != nil {
@@ -550,35 +544,6 @@ func (a *BuiltinAuth) sessionUser(r *http.Request) (User, bool) {
 // cliSignIn reports whether a next URL is a pending CLI sign-in.
 func cliSignIn(next string) bool { return strings.HasPrefix(next, "/auth/cli?") }
 
-// markFreshAuth records that userID just proved who they are in order to reach
-// this exact pending sign-in. Signing in IS the consent in that case: the user
-// chose the account seconds ago, for this, so a confirmation page would ask a
-// question they just answered — and a first `bdrive init` would cost two web
-// steps instead of one.
-//
-// Bound to the exact next and single use, so it can only ever skip the page for
-// the sign-in it was granted for, and only once. It is not reachable without
-// authenticating: an attacker who could set this could already click Approve.
-func (a *BuiltinAuth) markFreshAuth(userID, next string) {
-	if !cliSignIn(next) {
-		return
-	}
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	a.fresh[userID+"\x00"+next] = time.Now().Add(2 * time.Minute)
-}
-
-// consumeFreshAuth spends a marker if one is live, reporting whether the caller
-// may skip the confirmation.
-func (a *BuiltinAuth) consumeFreshAuth(userID, next string) bool {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	k := userID + "\x00" + next
-	exp, ok := a.fresh[k]
-	delete(a.fresh, k)
-	return ok && time.Now().Before(exp)
-}
-
 func (a *BuiltinAuth) startSession(w http.ResponseWriter, userID string) error {
 	tok, err := a.issueToken(userID, "web-session")
 	if err != nil {
@@ -600,10 +565,10 @@ func inviteBanner(next string) string {
 	return `<p class="msg" style="margin:0 0 14px">You've been invited to a team. Sign in (or sign up) to accept.</p>`
 }
 
-// cliBanner says what a sign-in reached from `bdrive login` is for. Without it
-// the form is a bare password prompt that happens to grant a terminal a token —
-// and since signing in here skips the confirmation page (see markFreshAuth),
-// this line is where that consent is actually informed.
+// cliBanner says what a sign-in reached from `bdrive login` is for, so the form
+// is not a bare password prompt appearing for no visible reason. Approving is
+// still its own step on the next page — this only explains why signing in is
+// being asked for at all.
 func cliBanner(next string) string {
 	if !cliSignIn(next) {
 		return ""
@@ -759,7 +724,6 @@ func (a *BuiltinAuth) pageLogin(w http.ResponseWriter, r *http.Request) {
 					http.Error(w, err.Error(), http.StatusInternalServerError)
 					return
 				}
-				a.markFreshAuth(u.ID, next)
 				http.Redirect(w, r, next, http.StatusSeeOther)
 				return
 			}
@@ -836,7 +800,6 @@ func (a *BuiltinAuth) pageSignup(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
-			a.markFreshAuth(u.ID, next)
 			http.Redirect(w, r, next, http.StatusSeeOther)
 			return
 		}
@@ -908,13 +871,6 @@ type authRequest struct {
 	// it — so it must be evaluated at render time, not at call time.
 	detail func() [][2]string
 
-	// freshAuthSkips lets authenticating for this request count as approving
-	// it, so a first sign-in is one web step rather than two. True only for the
-	// local flow: signing in and approving are the same act when the terminal
-	// is on this machine, and are emphatically not when the token goes to
-	// another one — see markFreshAuth.
-	freshAuthSkips bool
-
 	// live, when set, runs once the session is known and before anything is
 	// shown or granted, reporting whether the request still exists — having
 	// already written its own explanation when it doesn't. The device flow's
@@ -936,8 +892,7 @@ func (a *BuiltinAuth) pageAuth(w http.ResponseWriter, r *http.Request, req authR
 	if req.live != nil && !req.live() {
 		return
 	}
-	if r.Method == http.MethodPost ||
-		(req.freshAuthSkips && a.consumeFreshAuth(user.ID, r.URL.RequestURI())) {
+	if r.Method == http.MethodPost {
 		req.approve(user)
 		return
 	}
@@ -962,7 +917,6 @@ func (a *BuiltinAuth) pageCLI(w http.ResponseWriter, r *http.Request) {
 		},
 		note: `Approve this only if you just ran ` +
 			`<code style="white-space:nowrap">bdrive login</code> yourself.`,
-		freshAuthSkips: true,
 		approve: func(user User) {
 			code := a.newGrant("code", user.ID, "", true, time.Minute)
 			q := u.Query()

--- a/internal/webapp/authlocal.go
+++ b/internal/webapp/authlocal.go
@@ -518,6 +518,7 @@ func (a *BuiltinAuth) Register(mux *http.ServeMux) {
 	mux.HandleFunc("POST /auth/signup", a.pageSignup)
 	mux.HandleFunc("GET /auth/logout", a.pageLogout)
 	mux.HandleFunc("GET /auth/cli", a.pageCLI)
+	mux.HandleFunc("POST /auth/cli", a.pageCLI)
 	mux.HandleFunc("GET /auth/device/{token}", a.pageDevice)
 	mux.HandleFunc("POST /auth/device/{token}", a.pageDevice)
 	mux.HandleFunc("GET /auth/device", a.pageDeviceLegacy)
@@ -825,13 +826,21 @@ func (a *BuiltinAuth) pageLogout(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, dest, http.StatusSeeOther)
 }
 
-// pageCLI completes `bdrive login`: once the browser has a session, mint a
-// one-time code and bounce it to the CLI's loopback listener. Redirects are
-// restricted to loopback addresses so the code can't be sent anywhere else.
+// pageCLI completes `bdrive login`: confirm who the terminal will act as, then
+// mint a one-time code and bounce it to the CLI's loopback listener. Redirects
+// are restricted to loopback addresses so the code can't be sent anywhere else.
+//
+// The confirmation is the point, not ceremony. Whoever the browser happens to
+// be signed in as is who the terminal becomes, and that is frequently not the
+// account the user meant — a personal login left open, a teammate's session on
+// a shared machine. Granting silently means the mistake surfaces later, as a
+// synced folder full of commits authored by the wrong person, which is far
+// more work to undo than one click now.
+//
+// It also means a GET no longer grants anything, so a link someone else got
+// you to open can't mint a code on your behalf.
 func (a *BuiltinAuth) pageCLI(w http.ResponseWriter, r *http.Request) {
-	redirect := r.URL.Query().Get("redirect")
-	state := r.URL.Query().Get("state")
-	u, err := url.Parse(redirect)
+	u, err := url.Parse(r.URL.Query().Get("redirect"))
 	if err != nil || (u.Scheme != "http") || (u.Hostname() != "127.0.0.1" && u.Hostname() != "localhost" && u.Hostname() != "::1") {
 		http.Error(w, "invalid redirect (must be a loopback URL)", http.StatusBadRequest)
 		return
@@ -841,10 +850,22 @@ func (a *BuiltinAuth) pageCLI(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/auth/login?next="+url.QueryEscape(r.URL.String()), http.StatusSeeOther)
 		return
 	}
+
+	if r.Method != http.MethodPost {
+		authPage(w, "Sign in on this computer", fmt.Sprintf(
+			`<p class="lede">A terminal on this computer is asking to sign in to BearDrive.</p>
+%s%s
+<form method="post"><button>Approve</button></form>
+<p class="alt">Approve this only if you just ran <code>bdrive login</code> yourself.</p>`,
+			whoBlock(user, r.URL.RequestURI()),
+			rows([2]string{"Application", "bdrive command line"}, [2]string{"Waiting at", u.Host})))
+		return
+	}
+
 	code := a.newGrant("code", user.ID, "", true, time.Minute)
 	q := u.Query()
 	q.Set("code", code)
-	q.Set("state", state)
+	q.Set("state", r.URL.Query().Get("state"))
 	u.RawQuery = q.Encode()
 	http.Redirect(w, r, u.String(), http.StatusSeeOther)
 }
@@ -879,15 +900,22 @@ func (a *BuiltinAuth) pageDevice(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	authPage(w, "Connect a device", fmt.Sprintf(`<p class="lede">A device is asking to sign in to BearDrive.</p>
-%s
+%s%s
 <form method="post"><button>Approve</button></form>
 <p class="alt">Approve this only if you just started a sign-in on that machine.</p>`,
-		whoBlock(user, g, r.URL.RequestURI())))
+		whoBlock(user, r.URL.RequestURI()),
+		rows([2]string{"Device", g.device}, [2]string{"System", g.os}, [2]string{"Address", g.ip})))
 }
 
-// whoBlock renders the two things the approver needs: who they'd be granting
-// as (with an escape hatch back to this same page), and what is asking.
-func whoBlock(user User, g pendingGrant, back string) string {
+// whoBlock renders who the approver would be granting as, with an escape hatch
+// back to this same page. Approving on either flow hands a machine a token
+// that acts as you, so "as whom" is the question worth answering loudest — and
+// the browser's session is often not the account the user meant to use.
+//
+// What is asking differs per flow (a device has a name and an OS; a CLI on
+// this computer has a loopback port), so each page renders its own rows rather
+// than this pretending to a shape neither quite fits.
+func whoBlock(user User, back string) string {
 	name := user.Name
 	if name == "" {
 		name = user.Email
@@ -895,10 +923,20 @@ func whoBlock(user User, g pendingGrant, back string) string {
 	return fmt.Sprintf(`<div class="who">
 <div class="who-id"><span class="who-l">Signing in as</span><b>%s</b><span class="who-sub">%s</span></div>
 <a class="who-swap" href="/auth/logout?next=%s">Switch account</a>
-</div>
-<dl class="rows"><dt>Device</dt><dd>%s</dd><dt>System</dt><dd>%s</dd><dt>Address</dt><dd>%s</dd></dl>`,
-		html.EscapeString(name), html.EscapeString(user.Email), url.QueryEscape(safeNext(back)),
-		html.EscapeString(orDash(g.device)), html.EscapeString(orDash(g.os)), html.EscapeString(orDash(g.ip)))
+</div>`,
+		html.EscapeString(name), html.EscapeString(user.Email), url.QueryEscape(safeNext(back)))
+}
+
+// rows renders a label/value list, dashing out the blanks.
+func rows(pairs ...[2]string) string {
+	var b strings.Builder
+	b.WriteString(`<dl class="rows">`)
+	for _, p := range pairs {
+		fmt.Fprintf(&b, "<dt>%s</dt><dd>%s</dd>",
+			html.EscapeString(p[0]), html.EscapeString(orDash(p[1])))
+	}
+	b.WriteString(`</dl>`)
+	return b.String()
 }
 
 func orDash(s string) string {

--- a/internal/webapp/authlocal.go
+++ b/internal/webapp/authlocal.go
@@ -891,75 +891,129 @@ func (a *BuiltinAuth) pageLogout(w http.ResponseWriter, r *http.Request) {
 //
 // It also means a GET no longer grants anything, so a link someone else got
 // you to open can't mint a code on your behalf.
+// authRequest describes a pending sign-in to pageAuth. Both flows ask the user
+// the same question — "shall this thing act as you?" — and differ only in how
+// the request is identified, what is asking, and what approving does. Keeping
+// that difference in data rather than in two copies of the page is what stops
+// the two from drifting apart, which matters here: a flow whose disclosure
+// quietly falls behind the other's is the failure mode this page exists to
+// prevent.
+type authRequest struct {
+	title string // heading
+	lede  string // one line naming what is asking (plain text)
+	note  string // when approving is the right call — trusted markup
+
+	// detail is what is asking, in detail. A function because the device flow
+	// reads it off the pending grant, which only exists once live() has found
+	// it — so it must be evaluated at render time, not at call time.
+	detail func() [][2]string
+
+	// freshAuthSkips lets authenticating for this request count as approving
+	// it, so a first sign-in is one web step rather than two. True only for the
+	// local flow: signing in and approving are the same act when the terminal
+	// is on this machine, and are emphatically not when the token goes to
+	// another one — see markFreshAuth.
+	freshAuthSkips bool
+
+	// live, when set, runs once the session is known and before anything is
+	// shown or granted, reporting whether the request still exists — having
+	// already written its own explanation when it doesn't. The device flow's
+	// link expires; the CLI flow carries its whole request in the URL and has
+	// nothing to expire.
+	live func() bool
+
+	// approve performs the grant and writes the response.
+	approve func(user User)
+}
+
+// pageAuth is the approval page both sign-in flows share.
+func (a *BuiltinAuth) pageAuth(w http.ResponseWriter, r *http.Request, req authRequest) {
+	user, ok := a.sessionUser(r)
+	if !ok {
+		http.Redirect(w, r, "/auth/login?next="+url.QueryEscape(r.URL.RequestURI()), http.StatusSeeOther)
+		return
+	}
+	if req.live != nil && !req.live() {
+		return
+	}
+	if r.Method == http.MethodPost ||
+		(req.freshAuthSkips && a.consumeFreshAuth(user.ID, r.URL.RequestURI())) {
+		req.approve(user)
+		return
+	}
+	authPage(w, req.title, fmt.Sprintf(`<p class="lede">%s</p>
+%s%s
+<form method="post"><button>Approve</button></form>
+<p class="alt">%s</p>`,
+		html.EscapeString(req.lede), whoBlock(user, r.URL.RequestURI()), rows(req.detail()...), req.note))
+}
+
 func (a *BuiltinAuth) pageCLI(w http.ResponseWriter, r *http.Request) {
 	u, err := url.Parse(r.URL.Query().Get("redirect"))
 	if err != nil || (u.Scheme != "http") || (u.Hostname() != "127.0.0.1" && u.Hostname() != "localhost" && u.Hostname() != "::1") {
 		http.Error(w, "invalid redirect (must be a loopback URL)", http.StatusBadRequest)
 		return
 	}
-	user, ok := a.sessionUser(r)
-	if !ok {
-		http.Redirect(w, r, "/auth/login?next="+url.QueryEscape(r.URL.String()), http.StatusSeeOther)
-		return
-	}
-
-	// Signing in for this very sign-in already answered the question the page
-	// asks, so don't ask it twice: a first `bdrive init` would otherwise cost
-	// two web steps (sign in, then approve) where one will do.
-	if r.Method != http.MethodPost && !a.consumeFreshAuth(user.ID, r.URL.RequestURI()) {
-		authPage(w, "Sign in on this computer", fmt.Sprintf(
-			`<p class="lede">A terminal on this computer is asking to sign in to BearDrive.</p>
-%s%s
-<form method="post"><button>Approve</button></form>
-<p class="alt">Approve this only if you just ran <code style="white-space:nowrap">bdrive login</code> yourself.</p>`,
-			whoBlock(user, r.URL.RequestURI()),
-			rows([2]string{"Application", "bdrive command line"}, [2]string{"Waiting at", u.Host})))
-		return
-	}
-
-	code := a.newGrant("code", user.ID, "", true, time.Minute)
-	q := u.Query()
-	q.Set("code", code)
-	q.Set("state", r.URL.Query().Get("state"))
-	u.RawQuery = q.Encode()
-	http.Redirect(w, r, u.String(), http.StatusSeeOther)
+	a.pageAuth(w, r, authRequest{
+		title: "Sign in on this computer",
+		lede:  "A terminal on this computer is asking to sign in to BearDrive.",
+		detail: func() [][2]string {
+			return [][2]string{{"Application", "bdrive command line"}, {"Waiting at", u.Host}}
+		},
+		note: `Approve this only if you just ran ` +
+			`<code style="white-space:nowrap">bdrive login</code> yourself.`,
+		freshAuthSkips: true,
+		approve: func(user User) {
+			code := a.newGrant("code", user.ID, "", true, time.Minute)
+			q := u.Query()
+			q.Set("code", code)
+			q.Set("state", r.URL.Query().Get("state"))
+			u.RawQuery = q.Encode()
+			http.Redirect(w, r, u.String(), http.StatusSeeOther)
+		},
+	})
 }
 
 // pageDevice is the headless-login approval page, reached by opening the link
 // `bdrive login` printed: the token lives in the path, so there is no code to
-// read off one screen and type into another. It names the account the device
-// will act as (with a way to switch), and what is asking, because approving
-// hands that machine a token that acts as you.
+// read off one screen and type into another.
+//
+// Unlike the local flow this one never skips the page. The machine being
+// granted is not the one reading this, so the account, the device name, its OS
+// and its address are the only things standing between an approval and a
+// stranger's pending link.
 func (a *BuiltinAuth) pageDevice(w http.ResponseWriter, r *http.Request) {
 	token := r.PathValue("token")
-	user, ok := a.sessionUser(r)
-	if !ok {
-		http.Redirect(w, r, "/auth/login?next="+url.QueryEscape(r.URL.RequestURI()), http.StatusSeeOther)
-		return
+	var g pendingGrant
+	expired := func(when string) {
+		authPage(w, "Link expired", `<p class="err">This sign-in link `+when+`.</p>
+<p class="alt">Run <code style="white-space:nowrap">bdrive login --device</code> again for a fresh one.</p>`)
 	}
-	g, ok := a.peekGrant("device", token)
-	if !ok {
-		authPage(w, "Link expired", `<p class="err">This sign-in link is invalid, already used, or older than 10 minutes.</p>
-<p class="alt">Run <code>bdrive login --device</code> again for a fresh one.</p>`)
-		return
-	}
-	if r.Method == http.MethodPost {
-		if !a.grantDevice(token, user.ID) {
-			authPage(w, "Link expired", `<p class="err">This sign-in link expired while the page was open.</p>
-<p class="alt">Run <code>bdrive login --device</code> again for a fresh one.</p>`)
-			return
-		}
-		authPage(w, "Device connected", fmt.Sprintf(`<p class="msg">%s can now sync as %s.</p>
+	a.pageAuth(w, r, authRequest{
+		title: "Connect a device",
+		lede:  "A device is asking to sign in to BearDrive.",
+		note:  "Approve this only if you just started a sign-in on that machine.",
+		detail: func() [][2]string {
+			return [][2]string{{"Device", g.device}, {"System", g.os}, {"Address", g.ip}}
+		},
+		live: func() bool {
+			var ok bool
+			if g, ok = a.peekGrant("device", token); !ok {
+				expired("is invalid, already used, or older than 10 minutes")
+				return false
+			}
+			return true
+		},
+		approve: func(user User) {
+			if !a.grantDevice(token, user.ID) {
+				expired("expired while the page was open")
+				return
+			}
+			authPage(w, "Device connected", fmt.Sprintf(`<p class="msg">%s can now sync as %s.</p>
 <p class="alt">You can close this tab — the terminal finishes on its own.</p>`,
-			html.EscapeString(orDash(g.device)), html.EscapeString(user.Email)))
-		return
-	}
-	authPage(w, "Connect a device", fmt.Sprintf(`<p class="lede">A device is asking to sign in to BearDrive.</p>
-%s%s
-<form method="post"><button>Approve</button></form>
-<p class="alt">Approve this only if you just started a sign-in on that machine.</p>`,
-		whoBlock(user, r.URL.RequestURI()),
-		rows([2]string{"Device", g.device}, [2]string{"System", g.os}, [2]string{"Address", g.ip})))
+				html.EscapeString(orDash(g.device)), html.EscapeString(user.Email)))
+		},
+	})
 }
 
 // whoBlock renders who the approver would be granting as, with an escape hatch

--- a/internal/webapp/authlocal.go
+++ b/internal/webapp/authlocal.go
@@ -50,6 +50,11 @@ type BuiltinAuth struct {
 	// Ephemeral single-use state; a server restart just cancels pending
 	// logins and resets.
 	pending map[string]pendingGrant // auth codes, device codes, reset tokens
+
+	// fresh records that an account authenticated *for a specific pending
+	// sign-in*, so that sign-in doesn't ask again. Keyed by user id + the exact
+	// next URL, single use, short lived. See markFreshAuth.
+	fresh map[string]time.Time
 }
 
 type authUser struct {
@@ -96,6 +101,7 @@ func NewBuiltinAuth(store AccountRepo, allowSignup bool, mail *Mailer) (*Builtin
 		users:   make(map[string]*authUser),
 		tokens:  make(map[string]authToken),
 		pending: make(map[string]pendingGrant),
+		fresh:   make(map[string]time.Time),
 	}
 	users, tokens, policy, err := store.Load()
 	if err != nil {
@@ -541,6 +547,38 @@ func (a *BuiltinAuth) sessionUser(r *http.Request) (User, bool) {
 	return User{}, false
 }
 
+// cliSignIn reports whether a next URL is a pending CLI sign-in.
+func cliSignIn(next string) bool { return strings.HasPrefix(next, "/auth/cli?") }
+
+// markFreshAuth records that userID just proved who they are in order to reach
+// this exact pending sign-in. Signing in IS the consent in that case: the user
+// chose the account seconds ago, for this, so a confirmation page would ask a
+// question they just answered — and a first `bdrive init` would cost two web
+// steps instead of one.
+//
+// Bound to the exact next and single use, so it can only ever skip the page for
+// the sign-in it was granted for, and only once. It is not reachable without
+// authenticating: an attacker who could set this could already click Approve.
+func (a *BuiltinAuth) markFreshAuth(userID, next string) {
+	if !cliSignIn(next) {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.fresh[userID+"\x00"+next] = time.Now().Add(2 * time.Minute)
+}
+
+// consumeFreshAuth spends a marker if one is live, reporting whether the caller
+// may skip the confirmation.
+func (a *BuiltinAuth) consumeFreshAuth(userID, next string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	k := userID + "\x00" + next
+	exp, ok := a.fresh[k]
+	delete(a.fresh, k)
+	return ok && time.Now().Before(exp)
+}
+
 func (a *BuiltinAuth) startSession(w http.ResponseWriter, userID string) error {
 	tok, err := a.issueToken(userID, "web-session")
 	if err != nil {
@@ -560,6 +598,18 @@ func inviteBanner(next string) string {
 		return ""
 	}
 	return `<p class="msg" style="margin:0 0 14px">You've been invited to a team. Sign in (or sign up) to accept.</p>`
+}
+
+// cliBanner says what a sign-in reached from `bdrive login` is for. Without it
+// the form is a bare password prompt that happens to grant a terminal a token —
+// and since signing in here skips the confirmation page (see markFreshAuth),
+// this line is where that consent is actually informed.
+func cliBanner(next string) string {
+	if !cliSignIn(next) {
+		return ""
+	}
+	return `<p class="msg" style="margin:0 0 14px">A terminal on this computer is waiting to sign in. ` +
+		`The account you use here is the one it will act as.</p>`
 }
 
 // safeNext keeps post-login redirects on this site.
@@ -709,6 +759,7 @@ func (a *BuiltinAuth) pageLogin(w http.ResponseWriter, r *http.Request) {
 					http.Error(w, err.Error(), http.StatusInternalServerError)
 					return
 				}
+				a.markFreshAuth(u.ID, next)
 				http.Redirect(w, r, next, http.StatusSeeOther)
 				return
 			}
@@ -735,7 +786,7 @@ func (a *BuiltinAuth) pageLogin(w http.ResponseWriter, r *http.Request) {
 	if a.Brand != "" {
 		brand = `<p class="alt" style="margin:0 0 14px;color:var(--dim)">` + html.EscapeString(a.Brand) + `</p>`
 	}
-	authPage(w, "Sign in", brand+inviteBanner(next)+fmt.Sprintf(`<form method="post" action="/auth/login?next=%s">%s%s%s<button>Sign in</button></form>
+	authPage(w, "Sign in", brand+inviteBanner(next)+cliBanner(next)+fmt.Sprintf(`<form method="post" action="/auth/login?next=%s">%s%s%s<button>Sign in</button></form>
 %s<p class="alt"><a href="/auth/reset">Forgot password?</a></p>`,
 		url.QueryEscape(next),
 		field("Email", "email", "email", r.FormValue("email")),
@@ -785,6 +836,7 @@ func (a *BuiltinAuth) pageSignup(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
+			a.markFreshAuth(u.ID, next)
 			http.Redirect(w, r, next, http.StatusSeeOther)
 			return
 		}
@@ -801,7 +853,7 @@ func (a *BuiltinAuth) pageSignup(w http.ResponseWriter, r *http.Request) {
 	if a.Brand != "" {
 		brand = `<p class="alt" style="margin:0 0 14px;color:var(--dim)">` + html.EscapeString(a.Brand) + `</p>`
 	}
-	authPage(w, "Create account", brand+inviteBanner(next)+fmt.Sprintf(`<form method="post" action="/auth/signup?next=%s">%s%s%s%s%s<button>Sign up</button></form>
+	authPage(w, "Create account", brand+inviteBanner(next)+cliBanner(next)+fmt.Sprintf(`<form method="post" action="/auth/signup?next=%s">%s%s%s%s%s<button>Sign up</button></form>
 <p class="alt">Have an account? <a href="/auth/login?next=%s">Sign in</a></p>`,
 		url.QueryEscape(next),
 		field("Name", "name", "text", r.FormValue("name")),
@@ -851,7 +903,10 @@ func (a *BuiltinAuth) pageCLI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.Method != http.MethodPost {
+	// Signing in for this very sign-in already answered the question the page
+	// asks, so don't ask it twice: a first `bdrive init` would otherwise cost
+	// two web steps (sign in, then approve) where one will do.
+	if r.Method != http.MethodPost && !a.consumeFreshAuth(user.ID, r.URL.RequestURI()) {
 		authPage(w, "Sign in on this computer", fmt.Sprintf(
 			`<p class="lede">A terminal on this computer is asking to sign in to BearDrive.</p>
 %s%s

--- a/web/docs/src/content/docs/reference/cli.md
+++ b/web/docs/src/content/docs/reference/cli.md
@@ -9,7 +9,7 @@ One binary, `bdrive` — the CLI, the sync daemon, and the web server.
 
 | Command | Description |
 |---|---|
-| `bdrive login [server-url]` | Sign this device in. Browser flow; `--device` forces the approval-link flow, and shells without a TTY (agents, CI, SSH) fall back to it automatically. Default server is beardrive.ai — the managed cloud, free personal workspace on signup; pass your hub URL to self-host. Switch hubs with `bdrive login <new-url>`. `--status` shows the current server and account |
+| `bdrive login [server-url]` | Sign this device in. Browser flow — the page names the account this terminal would act as and lets you switch before approving; `--device` forces the approval-link flow, and shells without a TTY (agents, CI, SSH) fall back to it automatically. Default server is beardrive.ai — the managed cloud, free personal workspace on signup; pass your hub URL to self-host. Switch hubs with `bdrive login <new-url>`. `--status` shows the current server and account |
 | `bdrive logout` | Sign this device out — clear the saved token and account. `--forget` also drops the remembered server |
 | `bdrive init [folder]` | Create or connect a project and start syncing — the mount is always exactly the folder named. Interactive on a TTY; flags (`--name`, `--project`, `--server`, `--only`, `--yes`) for scripts. Also registers agent sync hooks for detected platforms (`--no-hooks` skips them) and a login item so sync resumes after a reboot (`--no-autostart` skips), and prints the project's hub link. Re-run to resume |
 | `bdrive resume` | Restart the sync daemon for every project on this device that isn't paused — after a reboot, a crash, or a manual kill. Idempotent, so running it twice is harmless. This is what the login item runs |

--- a/web/docs/src/content/docs/self-hosting/authentication.md
+++ b/web/docs/src/content/docs/self-hosting/authentication.md
@@ -59,9 +59,17 @@ server-config-owned, so a browser session can never widen who gets in.
 ## Device sign-in
 
 `bdrive login <url>` opens the server's sign-in page in a browser — sign up
-right there if needed. When the user signs in, the page bounces a one-time code
-to the CLI's loopback listener and the terminal finishes on its own, storing a
-long-lived per-device token that is revocable server-side.
+right there if needed. The page then asks you to confirm, naming the account
+the terminal would act as: whichever account that browser is signed in as is
+the one the terminal becomes, and it is often not the one you meant (a personal
+login left open, a teammate's session on a shared machine). **Switch account**
+signs you out and returns to the same pending sign-in, so picking the right one
+costs a click rather than a re-run.
+
+Approving bounces a one-time code to the CLI's loopback listener and the
+terminal finishes on its own, storing a long-lived per-device token that is
+revocable server-side. Approval is a POST from that page, so simply opening the
+link grants nothing.
 
 On headless or SSH machines login falls back to the device-code flow
 automatically (no TTY, or no browser can open): it prints one approval link to

--- a/web/docs/src/content/docs/self-hosting/authentication.md
+++ b/web/docs/src/content/docs/self-hosting/authentication.md
@@ -58,18 +58,19 @@ server-config-owned, so a browser session can never widen who gets in.
 
 ## Device sign-in
 
-`bdrive login <url>` opens the server's sign-in page in a browser — sign up
-right there if needed. The page then asks you to confirm, naming the account
-the terminal would act as: whichever account that browser is signed in as is
-the one the terminal becomes, and it is often not the one you meant (a personal
-login left open, a teammate's session on a shared machine). **Switch account**
-signs you out and returns to the same pending sign-in, so picking the right one
-costs a click rather than a re-run.
+Both sign-in flows end the same way: **an approval page you have to click.** It
+names the account the machine would act as, because that is what approving
+grants — whichever account the browser is signed in as is the one the terminal
+becomes, and it is often not the one you meant (a personal login left open, a
+teammate's session on a shared machine). **Switch account** signs you out and
+returns to the same pending sign-in, so picking the right one costs a click
+rather than a re-run. Approval is a POST from that page, so merely opening a
+sign-in link grants nothing.
 
-Approving bounces a one-time code to the CLI's loopback listener and the
-terminal finishes on its own, storing a long-lived per-device token that is
-revocable server-side. Approval is a POST from that page, so simply opening the
-link grants nothing.
+`bdrive login <url>` opens the server's sign-in page in a browser — sign up
+right there if needed — and lands on that approval page. Approving bounces a
+one-time code to the CLI's loopback listener and the terminal finishes on its
+own, storing a long-lived per-device token that is revocable server-side.
 
 On headless or SSH machines login falls back to the device-code flow
 automatically (no TTY, or no browser can open): it prints one approval link to


### PR DESCRIPTION
## TL;DR

- `bdrive login` used to hand a terminal a token as whoever the browser happened to be signed in as, silently — often not the account you meant.
- Both sign-in flows now end on the same approval page: it names that account, shows what is asking, and offers **Switch account**.
- One page and one handler for `/auth/cli` and `/auth/device` — they asked the same question with two copies of the code, and had already started drifting.
- A GET grants nothing now, so a sign-in link someone got you to open can't mint a code on your behalf.
- **Known trade:** a first `bdrive init` on a fresh machine is two web pages (sign in, then approve) rather than one. Deliberate — see below.

## The problem

Whoever the browser is signed in as is who the terminal becomes. A personal login left open in the default browser, a teammate's session on a shared machine — and the mistake surfaces much later, as a synced folder full of commits attributed to the wrong person. The `--device` flow already got this right in #83; the browser flow said nothing at all, for the same grant.

## The flow

```mermaid
flowchart TD
    A["bdrive login<br/>(or bdrive login --device)"] --> B{"signed in<br/>in this browser?"}
    B -- no --> C["<b>Sign in</b><br/>banner says a terminal is waiting"]
    C --> D
    B -- yes --> D["<b>Approval page</b><br/>names the account · what is asking · Switch account"]
    D -- "Switch account" --> C
    D -- "Approve (POST)" --> E{which flow}
    E -- "bdrive login" --> F["303 → 127.0.0.1:PORT/callback?code=…<br/>terminal finishes on its own"]
    E -- "--device" --> G["Device connected<br/>the polling CLI picks it up"]
```

Identical for both flows; they differ only in what the approval page can tell you, and in what approving does.

| | with no web session | already signed in |
|---|---|---|
| `bdrive login` | Sign in → **Approve** | **Approve** |
| `bdrive login --device` | Sign in → **Approve** | **Approve** |

## What it looks like

No web session: sign in, and the form says why it appeared.

![sign-in page with a banner reading "A terminal on this computer is waiting to sign in. The account you use here is the one it will act as."](https://raw.githubusercontent.com/runbear-io/beardrive/pr-assets/cli-login-confirmation/shots/1-first-time-login.png)

Then the approval page — the same page you get when you were already signed in. Signing in granted nothing on the way here.

![approval page: "Sign in on this computer", signing in as Me me@example.com with a Switch account link, Application "bdrive command line", Waiting at 127.0.0.1:61989, and an Approve button](https://raw.githubusercontent.com/runbear-io/beardrive/pr-assets/cli-login-confirmation/shots/2-approve.png)

**Switch account** returns to the *same* pending sign-in rather than the home page, so the terminal is still waiting when you come back as the right account. It lands back on the sign-in page above, still carrying the request:

```
/auth/logout?next=%2Fauth%2Fcli%3Fredirect%3D…  →  /auth/login?next=%2Fauth%2Fcli%3Fredirect%3D…
```

The device flow is the identical shape, differing only in what it can tell you — a machine that isn't the one reading the page, so its name, OS and address are what stand between an approval and a stranger's pending link:

![device approval page: "Connect a device", Device 4b79afdd4c66, System linux, Address ::1, Approve button](https://raw.githubusercontent.com/runbear-io/beardrive/pr-assets/cli-login-confirmation/shots/4-device-approve.png)

![after approving: "Device connected", 4b79afdd4c66 can now sync as me@example.com](https://raw.githubusercontent.com/runbear-io/beardrive/pr-assets/cli-login-confirmation/shots/5-device-connected.png)

## Why two pages for a first sign-in

An earlier revision of this branch let signing in count as its own approval, so a fresh `bdrive init` cost one page. It was dropped: it made the local flow one step and the device flow two, so the same product asked for consent in two different shapes depending on which machine you were on — and the shape that skipped the page was the one where the page had something to tell you. Consistency is worth the click. Removing it also deleted a map, two methods, a descriptor field and a branch, so `pageAuth` now has exactly one path through it.

## One handler

`pageAuth` owns the shape — session check, redirect to login, `whoBlock`, rows, the Approve form, the note — and each flow passes an `authRequest` for what differs: how the request is identified, what is asking, and what approving does. The duplication was already costing us: a text-wrapping fix landed on the CLI copy only, leaving the device page able to break `bdrive login --device` across two code boxes.

One asymmetry stays explicit in the descriptor rather than implicit in copied code: `live()` reports whether the request still exists, because the device link expires while the CLI flow carries its whole request in the URL and has nothing to expire. `detail` is a function, not a slice, since the device rows come off the pending grant that `live()` finds.

`whoBlock` lost its `pendingGrant` parameter and renders only the identity half, which is what let the CLI page reuse it at all.

## Testing

`go test ./...` green across all 10 packages; `go vet` clean.

- **`TestBothFlowsAlwaysAskToApprove`** runs one set of assertions over both flows as subtests: no session sends you to sign in carrying the request, signing in returns to the request *without* granting, the approval page appears every time, and only the POST grants.
- **`TestCLILoginSwitchAccount`** — switching preserves the pending sign-in, the page then names the new account and not the old one, and the token goes to whoever approved.
- `TestCLICallbackFlow` and `TestDeviceCodeFlow` pass unchanged.

Every screenshot above was captured against a hub built from this commit, by a Playwright walkthrough that **asserts each transition** rather than just snapping pages — page headings, that the sign-in carries the pending request, that the device rows are populated from a real pending grant, and that approving confirms. The device flow was driven end to end against a real `bdrive login --device` running in a container. Approving the CLI request returns `303 → http://127.0.0.1:61989/callback?code=…&state=…`, checked directly.

## Known gaps

- Approving is a POST with no CSRF token, same as before for the device page. Strictly better than the old GET, but if you want real CSRF protection it belongs on both pages at once.
- Still duplicated: `inviteBanner` and `cliBanner` are the same function twice (mine, ~5 lines), and four near-identical "Link expired" pages predate this branch.
- `internal/webapp/authlocal.go` and `markdown_test.go` already fail `gofmt` on main; I reverted the sweep so every hunk here is mine.
- Screenshots live on the orphan branch `pr-assets/cli-login-confirmation`; deleting it takes them with it. The device name in them is a container hostname, so it differs between runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgF8JsoeNPVShGYWdooE72
