### PR TITLE
fix(webapp): the e2e harness binds the port before it wipes anything (BEA-50)

### DIFF
--- a/internal/webapp/e2e_serve_test.go
+++ b/internal/webapp/e2e_serve_test.go
@@ -14,9 +14,12 @@ package webapp
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,11 +36,43 @@ const (
 	e2ePassword = "e2e-pass-1"
 )
 
+// e2eState is the fixed state dir TestE2EServe wipes and reseeds on every
+// start. Fixed on purpose (the determinism contract above) — which is why
+// listenHub has to run before anything touches it.
+func e2eState() string { return filepath.Join(os.TempDir(), "bdrive-e2e-hub") }
+
+// listenHub binds the port both harnesses share. Called BEFORE any state is
+// touched: a second run must not wipe a live hub's storage on its way to
+// failing to bind.
+func listenHub(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", e2eAddr)
+	if err != nil {
+		t.Fatalf("cannot bind %s (is an e2e or demo hub already running?): %v", e2eAddr, err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	return ln
+}
+
+// serveHub serves until d elapses or the server errors — an error after a
+// successful bind fails the test instead of vanishing into a goroutine.
+func serveHub(t *testing.T, ln net.Listener, h http.Handler, d time.Duration) {
+	t.Helper()
+	errc := make(chan error, 1)
+	go func() { errc <- http.Serve(ln, h) }()
+	select {
+	case err := <-errc:
+		t.Fatalf("serve: %v", err)
+	case <-time.After(d):
+	}
+}
+
 func TestE2EServe(t *testing.T) {
 	if os.Getenv("BDRIVE_E2E_SERVE") == "" {
 		t.Skip("frontend e2e harness; set BDRIVE_E2E_SERVE=1 to run")
 	}
-	state := filepath.Join(os.TempDir(), "bdrive-e2e-hub")
+	ln := listenHub(t) // before the wipe below: a busy port must cost nothing
+	state := e2eState()
 	if err := os.RemoveAll(state); err != nil {
 		t.Fatal(err)
 	}
@@ -122,8 +157,44 @@ func TestE2EServe(t *testing.T) {
 	srv.Shares = shares
 
 	t.Logf("e2e hub on http://%s (state: %s) — %s / %s", e2eAddr, state, e2eAdmin, e2ePassword)
-	go http.ListenAndServe(e2eAddr, srv.Handler())
-	time.Sleep(2 * time.Hour) // Playwright kills the process when the run ends
+	serveHub(t, ln, srv.Handler(), 2*time.Hour) // Playwright kills the process when the run ends
+}
+
+// TestHarnessFailsFastOnBoundPort is the regression test for the bug that
+// bit: a second TestE2EServe used to wipe a live hub's state dir on its way
+// to silently failing to bind. Ungated, so it runs in the normal suite.
+func TestHarnessFailsFastOnBoundPort(t *testing.T) {
+	if testing.Short() {
+		t.Skip("shells out to go test")
+	}
+	ln, err := net.Listen("tcp", e2eAddr)
+	if err != nil {
+		t.Skipf("%s already in use — nothing safe to prove: %v", e2eAddr, err)
+	}
+	defer ln.Close()
+
+	canary := filepath.Join(e2eState(), "canary.txt")
+	if err := os.MkdirAll(e2eState(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(canary, []byte("survive"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(canary)
+
+	cmd := exec.Command("go", "test", "-count=1", "-run", "TestE2EServe", "./internal/webapp")
+	cmd.Dir = "../.."
+	cmd.Env = append(os.Environ(), "BDRIVE_E2E_SERVE=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("harness started with %s already bound:\n%s", e2eAddr, out)
+	}
+	if !strings.Contains(string(out), "8993") {
+		t.Errorf("failure does not name the port:\n%s", out)
+	}
+	if b, err := os.ReadFile(canary); err != nil || string(b) != "survive" {
+		t.Errorf("state dir was wiped by a run that could not bind: %v %q", err, b)
+	}
 }
 
 // seedE2E journals a small fixed file tree (with history on one path and one

--- a/internal/webapp/manual_serve_test.go
+++ b/internal/webapp/manual_serve_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,6 +34,7 @@ func TestManualServe(t *testing.T) {
 	if os.Getenv("BDRIVE_MANUAL_SERVE") == "" {
 		t.Skip("manual demo harness; set BDRIVE_MANUAL_SERVE=1 to run")
 	}
+	ln := listenHub(t) // before any state is touched — same port as the e2e harness
 	state := os.Getenv("BDRIVE_MANUAL_STATE")
 	if state == "" {
 		state = filepath.Join(os.TempDir(), "bdrive-demo-hub")
@@ -84,9 +84,8 @@ func TestManualServe(t *testing.T) {
 	auth.Admins = map[string]bool{"snow@runbear.io": true}
 	srv.Auth = auth
 
-	t.Logf("serving on http://0.0.0.0:8993 (state: %s) — snow@runbear.io / password1", state)
-	go http.ListenAndServe("0.0.0.0:8993", srv.Handler())
-	time.Sleep(8 * time.Hour)
+	t.Logf("serving on http://%s (state: %s) — snow@runbear.io / password1", e2eAddr, state)
+	serveHub(t, ln, srv.Handler(), 8*time.Hour)
 }
 
 // demoDevices is the agent fleet: one per teammate plus shared CI. Each has a


### PR DESCRIPTION
## TL;DR

- Running `go test -run TestE2EServe` while a hub was already on :8993 wiped the live hub's storage, then slept for 2h pretending to serve — the running hub kept answering with an empty file tree and nobody saw an error.
- The harness now grabs the port **first**: busy port → immediate `t.Fatal` naming :8993, and nothing on disk is touched.
- `TestManualServe` had the identical discarded-error bind on the same port — same fix.
- A serve error *after* a successful bind now fails the test instead of vanishing into a goroutine.
- Known gap, out of scope: `reuseExistingServer: true` still means `npm run e2e` silently runs against a `TestManualServe` demo hub if one is up.

Fixes BEA-50.

## The bug

Both harnesses started their hub the same way:

```go
go http.ListenAndServe(e2eAddr, srv.Handler())   // error discarded
time.Sleep(2 * time.Hour)
```

`ListenAndServe` runs in a goroutine, so `address already in use` went nowhere. `TestE2EServe` compounded it: its state dir is a fixed path (`os.TempDir()/bdrive-e2e-hub`) opened with `os.RemoveAll(state)` — and the wipe happened *before* any attempt to bind. A second run therefore destroyed the first run's storage and then quietly did nothing for two hours.

What the first server did next is the nasty part: it kept :8993 and kept answering. Its `remote.Backend` read through to a deleted directory (empty tree) while its `ReadLedger`, loaded at startup, still served read heat. From the UI that is indistinguishable from an empty project — which is how a whole pipeline run's worth of persona tours got conducted against a hub with no files.

## The fix

Ordering, plus one pair of helpers shared by both harnesses (same package, so it's free):

- `listenHub(t)` — `net.Listen` on `e2eAddr`, `t.Fatalf` naming the port and the likely cause if it's taken. Called as the first statement after the env-var skip, **above** `os.RemoveAll`.
- `serveHub(t, ln, h, d)` — serves until `d` elapses or `http.Serve` returns, handing the error back over a channel so `t.Fatalf` runs on the test goroutine.

`os.RemoveAll(state)` stays exactly as it was — it's the determinism contract the Playwright suite depends on. Only its position relative to the bind changed.

```
before:  skip-check → RemoveAll(state) → seed → go ListenAndServe (err dropped) → sleep 2h

after:   skip-check → Listen(:8993) ──fail──→ t.Fatal, disk untouched
                                  └──ok────→ RemoveAll(state) → seed → Serve(ln)
                                                                        └─ err → t.Fatal
```

`TestManualServe` gets the same two calls, drops its now-unused `net/http` import, and logs `e2eAddr` instead of a second hardcoded `0.0.0.0:8993`.

## Regression test

`TestHarnessFailsFastOnBoundPort` (ungated, runs in the normal suite) is the only thing that can assert the part that actually bit — *state untouched*. It holds :8993, drops a canary file in the state dir, shells out to `BDRIVE_E2E_SERVE=1 go test -run TestE2EServe ./internal/webapp`, and asserts: non-zero exit, output names the port, canary still readable. If :8993 is already taken by something else it skips rather than failing — a flaky "port busy" failure would be worse than no signal.

Mutation-checked: moving `listenHub(t)` back below `os.RemoveAll` makes it fail with `state dir was wiped by a run that could not bind`.

## Acceptance

Verified against a real live hub that happened to be holding :8993 during the build (the exact scenario in the report):

| Criterion | Result |
| -- | -- |
| `BDRIVE_E2E_SERVE=1 go test -run TestE2EServe` with the port taken | fails in 0.00s: `cannot bind 0.0.0.0:8993 (is an e2e or demo hub already running?)` |
| State dir unchanged in that case | 22 files, identical checksum before and after; the live hub kept serving (200 on `/auth/login`) |
| `BDRIVE_MANUAL_SERVE=1 go test -run TestManualServe` with the port taken | fails the same way; demo state dir never even created |
| `go test ./...` | all packages pass |
| `npm run e2e` with the port free | see below |

## Notes

- No production surface: both files are `_test.go` harnesses behind env vars. No CLI, flag, output or layout change, so no README / `INSTALL_FOR_AGENTS.md` / `web/docs` updates and no architecture-diagram change.
- Per-process state dirs were considered and rejected in the spec: the port is the contended resource, and Playwright's fixed `baseURL` plus the harness's "same world every start" contract both assume one hub at one address.

`npm run e2e`: **97/97 passed** on the branch, twice in a row (47.6s, 46.7s), against `97/97` in 52.1s on `origin/main` — same suite, same timings. (Two earlier runs on this branch flaked on 2 and 4 tests respectively while the machine still had a leftover hub process around; both went green once the port was genuinely free, and the failures were assertion/timeout flakes, not a dead server.)

## Build session

```
cd $(git worktree list | grep bea-50-ph-scan-bug | awk '{print $1}') && claude --resume eab34af2-aad3-42f1-a50a-f745644d2e85
```

(Only works on the machine this branch was built on.)
