### PR TITLE
test(webapp): pin "a read member sees grants and public links" (BEA-69)

### DIFF
--- a/internal/webapp/frontend/src/components/ShareBanner.tsx
+++ b/internal/webapp/frontend/src/components/ShareBanner.tsx
@@ -12,7 +12,13 @@ import { revokeShare, shareDetail } from "./SharesTable";
 
    Anyone with read sees the banner (a member should know the folder they
    rely on is exposed); Revoke is offered where the Share button already is,
-   and the server checks again anyway. */
+   and the server checks again anyway.
+
+   Same decision, one surface wider: project Settings shows a read-only member
+   every active public link and who created it (BEA-69 — the owner's call,
+   benchmarked against Google Drive showing a viewer who has access). Neither
+   this banner nor that list is a leak to hide later; both routes stay
+   PermRead. */
 export function ShareBanner({
   shares,
   canRevoke,

--- a/internal/webapp/perms.go
+++ b/internal/webapp/perms.go
@@ -141,6 +141,13 @@ func permDenied(level string) string {
 // handleProjectPerms returns the project's permission settings: the default
 // level, the caller's own effective level, and the explicit grants. Any member
 // with read may look; the grants are org-internal, not secrets.
+//
+// Re-confirmed by the owner in BEA-69 after a read-only member reported seeing
+// the whole People matrix: the benchmark is Google Drive, where a viewer can
+// see who has access, and hiding grants makes "why can't I edit this?"
+// unanswerable. Same call for the project's public-links list
+// (handleShareList, also PermRead). Raising either to PermWrite is a product
+// decision, not a hardening fix — TestReadMemberSeesSharesAndGrants pins both.
 func (s *Server) handleProjectPerms(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("project")
 	p, ok := s.project(w, r, id, PermRead)

--- a/internal/webapp/perms_test.go
+++ b/internal/webapp/perms_test.go
@@ -337,6 +337,58 @@ func TestPermissionsGET(t *testing.T) {
 	}
 }
 
+// A read member sees the People matrix and the project's public links, creator
+// included. Deliberate, and answered by the owner (BEA-69, 2026-08-03): the
+// benchmark is Google Drive, where a viewer can see who has access — hiding
+// grants makes "why can't I edit this?" unanswerable, and the per-file
+// ShareBanner already tells a read-only member the file they rely on is
+// public. TestReadOnlyMemberRoutes only checks these two routes are not 403,
+// so an "improvement" that returned an empty body to read members would pass
+// every other test in the repo. Tightening either route to PermWrite is a
+// product decision, not a hardening fix; this test is here so it cannot happen
+// by accident.
+func TestReadMemberSeesSharesAndGrants(t *testing.T) {
+	h, srv, c, p := permHub(t)
+	if err := srv.Projects.SetPerm(p.ID, "bob@x.io", PermRead); err != nil {
+		t.Fatal(err)
+	}
+	sh, err := srv.Shares.Create(p.ID, "x.md", "alice@x.io", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := doAs(t, h, "GET", "/api/p/"+p.ID+"/shares", nil, c["bob"])
+	if rec.Code != 200 {
+		t.Fatalf("GET shares as a read member: %d %s", rec.Code, rec.Body)
+	}
+	var out struct {
+		Shares []map[string]any `json:"shares"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Shares) != 1 {
+		t.Fatalf("shares = %+v, want the one link alice minted", out.Shares)
+	}
+	got := out.Shares[0]
+	if got["token"] != sh.Token || got["path"] != "x.md" {
+		t.Errorf("share = %+v, want token %q on x.md", got, sh.Token)
+	}
+	if url, _ := got["url"].(string); !strings.HasSuffix(url, "/s/"+sh.Token) {
+		t.Errorf("url = %q, want it to end in /s/%s", url, sh.Token)
+	}
+	// The field the issue is actually about, and the one a hardening pass
+	// would strip first. It exposes nothing new: the People table already
+	// shows every member's email to every member.
+	if got["creator"] != "alice@x.io" {
+		t.Errorf("creator = %v, want alice@x.io", got["creator"])
+	}
+	// And the grants alongside it, from the same read-only session.
+	rec = doAs(t, h, "GET", "/api/p/"+p.ID+"/permissions", nil, c["bob"])
+	if rec.Code != 200 || !strings.Contains(rec.Body.String(), "bob@x.io") {
+		t.Fatalf("GET permissions as a read member: %d %s", rec.Code, rec.Body)
+	}
+}
+
 // The project list carries the caller's level *alongside* every ordinary
 // Project field. Regression guard: an earlier version hand-listed the fields
 // it returned, which silently dropped description and icon the moment those


### PR DESCRIPTION
## TL;DR

- A read-only member seeing the People matrix and every public link is **on purpose** — nothing changes for any role.
- The problem was that nothing asserted it: strip the `creator` field, or return `{"shares": []}` to read members, and every test in the repo still passed.
- Adds one test that fails if either happens, and extends the two rationale comments instead of adding a third copy.
- No route change, no UI change, no new gating. `internal/webapp/static` is byte-identical (the frontend edit is a comment).
- Known gap: this pins the *decision*, not the field list — if review finds something in `shareJSON` a read member genuinely shouldn't see, that's a new issue, not a widening of this one.

Closes BEA-69.

## Why a test-only PR

The report was "a read-only member sees the whole sharing and membership surface". The owner's answer (BEA-69, 2026-08-03) was to keep both surfaces: the benchmark is Google Drive, where a viewer can see who has access — hiding grants makes "why can't I edit this?" unanswerable, and the per-file `ShareBanner` already tells a read-only member the file they rely on is public.

So the deliverable is to stop it being re-litigated. Three of the four acceptance criteria already held; one didn't.

| Acceptance criterion | Before | This PR |
| -- | -- | -- |
| 200 + populated body from `GET …/permissions` | `TestPermissionsGET` ✅ | unchanged |
| 200 + populated body from `GET …/shares` | only *not 403* ❌ | **the one real gap** |
| a write route refuses that member | `TestReadOnlyMemberRoutes`, 13 routes ✅ | unchanged |
| rationale where the next reader lands | partial | two comments extended |

`TestReadOnlyMemberRoutes` walks `GET …/shares` in its not-403 list, which says the route is reachable and nothing about what it returns.

## What's in the diff

- **`perms_test.go` — `TestReadMemberSeesSharesAndGrants`.** Signs bob in at `PermRead`, mints a link as alice, and asserts the read-only session gets 200 with that one share: `token`, `path`, a `url` ending in `/s/<token>`, and `creator == "alice@x.io"` — the field a hardening pass would strip first. Then re-checks `GET …/permissions` from the same session. The doc comment carries the owner's answer so the next reader doesn't re-open the debate.
- **`perms.go`** — extends the existing *"the grants are org-internal, not secrets"* comment on `handleProjectPerms` with the Drive benchmark, the BEA-69 reference, and a pointer that `handleShareList` is the same call.
- **`ShareBanner.tsx`** — extends its existing parenthetical to name the project-wide list in Settings as the same decision. Comment only; `npm run build` produces identical output, so `static/` is untouched and `check-dist.sh` stays green.

**On asserting that an email is returned:** out of context that reads like a red flag. It isn't — the People table already shows every member's email to every member, so `creator` exposes nothing new. That was explicit in the answer.

## Verification

- `go test ./...` — pass.
- `go vet ./...` — clean.
- `npm run build` in `internal/webapp/frontend` — `internal/webapp/static` unchanged (verified with `git status`).
- `npm run e2e` — 147 passed, 1 skipped.
- Negative check: with `out["creator"]` removed from `shareJSON`, the new test fails (`creator = <nil>, want alice@x.io`); reverted.

No frontend behavior changed, so there is nothing to screenshot — the rendered UI is identical to `main`.

## Build session

```
cd $(git worktree list | grep bea-69 | awk '{print $1}') && claude --resume c5814740-5549-42a7-8de0-bbc8bf106b3e
```

(only works on this machine)
