### PR TITLE
fix(webapp): share page dark mode no longer shows white slabs (BEA-71)

### DIFF
--- a/internal/webapp/shares.go
+++ b/internal/webapp/shares.go
@@ -524,8 +524,6 @@ const sharedMarkdownShell = `<!doctype html><html lang="en"><head><meta charset=
 body{font:16px/1.7 -apple-system,BlinkMacSystemFont,"SF Pro Text","Inter","Segoe UI",sans-serif;color:#24292f;
 max-width:720px;margin:0 auto;padding:52px 24px 96px}
 a{color:#b26a00}
-@media (prefers-color-scheme: dark){body{background:#0a0b0d;color:#c6cbd3}
-a{color:#ffcf85}code,pre{background:#15171b}h1,h2,h3{color:#f4f6f9}}
 h1,h2,h3{line-height:1.25;letter-spacing:-.018em}
 pre{padding:12px;border-radius:8px;overflow-x:auto;background:#f6f8fa}
 code{background:#f6f8fa;padding:2px 5px;border-radius:4px;font-size:.9em}
@@ -542,7 +540,22 @@ pre{max-width:100%%}
 footer.bdrive{margin-top:64px;padding-top:14px;border-top:1px solid #d0d7de;font-size:12.5px;color:#57606a}
 footer.bdrive a{color:inherit}
 .updated{font-size:12.5px;color:#57606a;margin-bottom:28px}
-@media (prefers-color-scheme: dark){footer.bdrive{border-color:#3a3a44;color:#888}.updated{color:#888}}
+/* Dark theme LAST: these rules sit at the same specificity as the light ones
+   above, so source order is the whole fix — a dark block placed earlier loses
+   to every light rule that follows it. Values are the hub's @theme tokens
+   (frontend/src/tw.css), never hand-picked, so the two surfaces agree. */
+@media (prefers-color-scheme: dark){
+body{background:#0a0b0d;color:#eef0f3}
+a{color:#ffcf85}
+h1,h2,h3{color:#eef0f3}
+pre,code{background:#15171b}
+blockquote{border-left-color:rgba(255,255,255,.07);color:#9aa0a9}
+td,th{border-color:rgba(255,255,255,.07)}
+table.frontmatter{background:#15171b;color:#9aa0a9}
+table.frontmatter th,table.frontmatter td{border-bottom-color:rgba(255,255,255,.07)}
+table.frontmatter th{color:#868b93}
+footer.bdrive{border-top-color:rgba(255,255,255,.07);color:#868b93}
+.updated{color:#868b93}}
 </style></head><body>%s%s
 <footer class="bdrive">Shared with <a href="https://github.com/runbear-io/beardrive" rel="noopener">BearDrive</a> — synced files for AI agent teams</footer>
 </body></html>`

--- a/internal/webapp/shares_test.go
+++ b/internal/webapp/shares_test.go
@@ -433,6 +433,46 @@ func TestShareLastUpdatedStamp(t *testing.T) {
 	}
 }
 
+// TestShareDarkThemeIsLast: the share page is the surface strangers see first,
+// so in dark mode it must not show white slabs. Every dark rule sits at the
+// same specificity as the light one it overrides, which makes SOURCE ORDER the
+// whole feature — a dark block placed before the light rules (as it was) loses
+// silently and the page still renders light. Assert placement, not presence.
+func TestShareDarkThemeIsLast(t *testing.T) {
+	srv, p, _, f, h := shareHub(t)
+	f.put("dev1", "wiki/themed.md", "---\ntitle: Q3\n---\n\n# Q3\n\n> quote\n\n| a | b |\n| - | - |\n| 1 | 2 |\n\n```go\nx := 1\n```\n")
+	token, _ := authedShare(t, srv, h, p.ID, "wiki/themed.md")
+	body := do(t, h, "GET", "/s/"+token, nil).Body.String()
+
+	if strings.Contains(body, "%!") {
+		t.Fatalf("format verb leaked into the page (a %% needs doubling in the const): %s", body)
+	}
+	dark := strings.LastIndex(body, "prefers-color-scheme")
+	if dark < 0 {
+		t.Fatal("no dark block at all")
+	}
+	// Every light surface colour must be settled before the dark block opens.
+	for _, light := range []string{"#f6f8fa", "#d0d7de", "#d8dee4", "#6e7781", "#57606a"} {
+		if i := strings.LastIndex(body, light); i > dark {
+			t.Errorf("light literal %s at %d comes after the dark block at %d — it wins in dark mode", light, i, dark)
+		}
+	}
+	// ...and the dark block has to actually cover the surfaces that were light.
+	block := body[dark:]
+	for _, sel := range []string{"pre,code{background:#15171b}", "blockquote{", "td,th{", "table.frontmatter{", "footer.bdrive{"} {
+		if !strings.Contains(block, sel) {
+			t.Errorf("dark block has no rule for %q", sel)
+		}
+	}
+	// Hub tokens, not a hand-picked palette (tw.css: --color-text, --color-bg).
+	if !strings.Contains(block, "background:#0a0b0d;color:#eef0f3") {
+		t.Error("dark body must use the hub's bg/text tokens")
+	}
+	if strings.Contains(body, "#c6cbd3") || strings.Contains(body, "#3a3a44") {
+		t.Error("ad-hoc dark greys survived; use the tw.css tokens")
+	}
+}
+
 func jsonReq(t *testing.T, method, url string, body any) *http.Request {
 	t.Helper()
 	var data []byte


### PR DESCRIPTION
## TL;DR

- A shared file opened on a dark-mode machine showed a **white frontmatter slab, a white code block and light-grey table borders** on a near-black page — the first thing a stranger sees, looking like a different product.
- The page already followed the system. Its dark `@media` block just sat **above** the light rules at equal specificity, so every light rule after it won.
- Fix is source order: move the dark block to the end of the stylesheet and finish it there. That repairs `pre`/`code` for free.
- Dark values now come from the hub's `tw.css` tokens instead of hand-picked greys (`#c6cbd3`, `#3a3a44`, `#888`) — that ad-hoc palette was the other half of the complaint.
- **Known gap, already agreed** (Snow, 2026-08-03): a *light*-system visitor still gets a light share page next to a permanently dark hub. That ends when the hub gets a light theme, deferred to its own issue.

## What was actually broken

The spec listed four unthemed rules. It was six — `pre` and `code` had a dark override that never took effect, because it was declared before the light rules it was meant to beat.

| Rule | Dark override before | After |
| --- | --- | --- |
| `body` bg + text | yes, but `#c6cbd3` text | `#0a0b0d` / `#eef0f3` |
| `a` | yes | unchanged (`#ffcf85`) |
| `pre`, `code` background | **declared, but lost the cascade** | `#15171b` |
| `blockquote` border + text | **none** | `rgba(255,255,255,.07)` / `#9aa0a9` |
| `td`, `th` borders | **none** | `rgba(255,255,255,.07)` |
| `table.frontmatter` background | **none** — a white slab | `#15171b` |
| `table.frontmatter` borders + label | **none** | `rgba(255,255,255,.07)` / `#868b93` |
| `footer.bdrive`, `.updated` | yes, but `#3a3a44` / `#888` | real tokens |

Values are the `@theme` tokens in `internal/webapp/frontend/src/tw.css`, not picked by eye, which is what makes the two surfaces agree.

The overrides use `border-left-color` / `border-color` / `border-bottom-color` rather than the `border` shorthand, so the light rules keep owning width and style and only the colour is themed.

## Dark mode, before and after

| Before | After |
| --- | --- |
| ![desktop dark before](https://raw.githubusercontent.com/runbear-io/beardrive/pr-assets/bea-71-ph-scan-bug-public-share-page-renders-light-while-the-hub/shots/share-dark-before.png) | ![desktop dark after](https://raw.githubusercontent.com/runbear-io/beardrive/pr-assets/bea-71-ph-scan-bug-public-share-page-renders-light-while-the-hub/shots/share-dark-after.png) |
| ![mobile dark before](https://raw.githubusercontent.com/runbear-io/beardrive/pr-assets/bea-71-ph-scan-bug-public-share-page-renders-light-while-the-hub/shots/share-mobile-dark-before.png) | ![mobile dark after](https://raw.githubusercontent.com/runbear-io/beardrive/pr-assets/bea-71-ph-scan-bug-public-share-page-renders-light-while-the-hub/shots/share-mobile-dark-after.png) |

Same document both sides: frontmatter table, blockquote, table, inline code, code block.

## The one thing to actually check

That the diff contains **no light-mode literal and no response header**. Light mode has to be untouched, and `/s/*` keeps its sandbox CSP / `nosniff` / referrer policy (CLAUDE.md invariant — those live on the handler, not in this const, and nothing here goes near them).

Evidence rather than assertion:

- Light-mode screenshots rendered from the pre- and post-fix pages are **byte-identical PNGs** (same SHA-256). Computed styles for `body`, `pre`, `code`, `blockquote`, `td`, `table.frontmatter`, `footer` match exactly on both sides.
- `TestShareLastUpdatedStamp` already asserts the three headers, and still passes.

## Test

`TestShareDarkThemeIsLast` asserts **placement, not presence** — deliberately. "A dark rule exists" passed while the page was still wrong, so the test checks the dark block comes after the last light literal (`#f6f8fa`, `#d0d7de`, `#d8dee4`, `#6e7781`, `#57606a`), covers each previously-light selector, and that no ad-hoc grey survived. It renders through the real handler, so the `fmt.Sprintf` format string still has to work — a `%` that wasn't doubled would surface as `%!`, which the test also catches.

Confirmed regression-shaped: reverted `shares.go` and re-ran it — 6 failures.

## What was run

| Check | Result |
| --- | --- |
| `go build ./... && go vet ./...` | clean |
| `go test ./...` | all packages pass |
| `npm run e2e` | 150 passed, 1 skipped |
| UI eval, desktop + mobile, dark + light | real rendered page, screenshots above |
| Contrast on `#0a0b0d` | body `#eef0f3` 17.25:1, dim 7.48:1, faint 5.75:1, link 13.61:1 — all past 4.5:1 |

No syncer test: this touches no sync path. No frontend build: the CSS is a Go const, `internal/webapp/static` is untouched.

## Architecture

No diagram change — no types, seams or relationships moved. One CSS const and one test.

## Deviation from the plan

None. The plan's own correction to the spec (six rules, not four; move the block rather than patch it in place) held up against the code.

## Build session

```
cd $(git worktree list | grep bea-71-ph-scan-bug | awk '{print $1}') && claude --resume ad9bedc5-d0a5-495c-b672-c6d3b9313f24
```

Only works on the machine that ran the build.
