### PR TITLE
docs: the ⌘K palette description matches what it actually offers (BEA-84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,8 +496,9 @@ The payoff, once those hooks are in place: "write a report and share it"
 becomes the agent generating `wiki/report.html` and replying with a link.
 
 The web UI lists your orgs' projects in the sidebar (⌘K opens a command
-palette: fuzzy file search, project switching, share/history/upload
-actions); selecting one browses that project's files, and the **History**
+palette: fuzzy file search, project switching, the project's own pages, and
+history — plus share and download of the file you have open); selecting one
+browses that project's files, and the **History**
 view shows every change — which
 account made it, when, from which device (name and OS — never the connecting
 IP), with view/download of any past version (content is

--- a/internal/webapp/frontend/src/components/Palette.tsx
+++ b/internal/webapp/frontend/src/components/Palette.tsx
@@ -5,7 +5,7 @@ import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 
 /* ---- command palette (⌘K / Ctrl+K) ----
    One box for everything: fuzzy-jump to any file, switch projects, and run
-   quick actions (share, history, upload, download, sign out). */
+   quick actions (history always, share and download on a file, sign out). */
 
 export interface PaletteItem {
   icon: string;


### PR DESCRIPTION
## TL;DR

- The README promised the ⌘K palette could **upload**. It never could — readers go hunting for a control that isn't there.
- Two surfaces said it, not one: `README.md:499` and the doc comment at `Palette.tsx:8`.
- Also fixed while in there: `download` was real but unmentioned, and share/download are **file-scoped** — the README now says so.
- Prose and a comment only. No code path touched, `static/` rebuilds byte-identical.
- Known gap, deliberately not fixed here: the palette still offers `Share:` to read-only members (see Concern).

## What the README claimed vs. what the palette builds

Every palette item is built in `internal/webapp/frontend/src/apps/Browser.tsx:293-320`.

| Promised at README:499 | Reality |
| --- | --- |
| `history` | works — always listed, file **or** folder |
| `share` | works, but **only when a file is open** (`isFile`, `Browser.tsx:306`) |
| `upload` | **does not exist anywhere** — browser upload is deliberately absent (`Browser.tsx:175`) |
| — | `download` is real and was **missing** from the sentence |

The original report said "no share action." That was a correct observation of a
folder route (`History: notes`) and a wrong conclusion about the palette: on a
folder, `isFile` is false and share/download are correctly hidden. Nobody should
go looking for a missing share implementation — there isn't one.

## The change

`README.md:498-500`:

```diff
 The web UI lists your orgs' projects in the sidebar (⌘K opens a command
-palette: fuzzy file search, project switching, share/history/upload
-actions); selecting one browses that project's files, and the **History**
+palette: fuzzy file search, project switching, the project's own pages, and
+history — plus share and download of the file you have open); selecting one
+browses that project's files, and the **History**
```

`internal/webapp/frontend/src/components/Palette.tsx:8`:

```diff
-   quick actions (share, history, upload, download, sign out). */
+   quick actions (history always, share and download on a file, sign out). */
```

## No assets to commit

`Palette.tsx` changes a comment, and source comments are stripped from the
bundle — `npm run build` in `internal/webapp/frontend` reproduced
`internal/webapp/static` byte-identically (same hashed filenames, clean
`git status`). Verified rather than assumed, since a stale `static/` is what
`frontend/check-dist.sh` exists to catch.

## What was run

- `go build ./...`, `go vet ./...` — clean
- `go test ./...` — all 11 packages pass
- `npm run e2e` (Playwright, seeded hub on :8993) — 153 passed, 1 pre-existing skip
- `npm run build` — no `static/` drift
- Acceptance greps, both empty: `grep -rni upload README.md .../Palette.tsx | grep -i palette` and `grep -rni palette web/docs/src/content/docs/`

No screenshots: nothing visual changed, so there is nothing to look at.

## Concern

Noticed while verifying, left out of scope: the palette gates `Share: <path>` on
`isFile` alone, while the toolbar's `canShare` (`Browser.tsx:164`) also requires
`atLeast(project.perm, "write")`. A read-only member sees the palette action and
gets a server rejection on activation. Real, unrelated to a docs fix, and worth
its own issue — should I file it, or is it already covered by the permissions
work in flight?

Adding a palette upload action stays BEA-25's call, not this PR's.

Closes BEA-84.

## Build session

```
cd $(git worktree list | grep bea-84-ph-scan-bug-readme-promises | awk '{print $1}') && claude --resume 5e067033-c84b-4d91-921a-1c2d02f05418
```

(only works on this machine)
