### PR TITLE
perf(webapp): history stops re-downloading every journal on every request (BEA-85)

### DIFF
--- a/architecture/webapp-server.md
+++ b/architecture/webapp-server.md
@@ -59,13 +59,23 @@ classDiagram
         -verify(ctx, sha) re-hash until sealed
         -blobStat(ctx, blob) remote.Object
         -sealed sync.Map sha→proved immutable
+        -jcache map key→cachedJournal
+        -jbytes int64 raw bytes cached
         -loadSourcedOps(ctx) []sourcedOp
+        -cacheJournals(keep, misses, parsed, sizes)
         -appendOp(ctx, op)
     }
     class sourcedOp {
         +Op journal.Op
         +From journal key's device
     }
+    class cachedJournal {
+        +size int64
+        +mod time.Time
+        +bytes int64
+        +ops []journal.Op
+    }
+    note for cachedJournal "Journals only GROW — a device appends only to its own, and appendOp rewrites its key with strictly more bytes — so the (Size, Modified) List already reports proves a parse is still current. That is why the cache needs no expiry and no new Backend method: loadSourcedOps still Lists on every request, and fetches only the keys whose size or mtime moved (concurrently, limit 8). History used to re-download and re-parse EVERY journal per page, which is what made it 8-10s and made paging cost more rather than less. Bounded by a per-project raw-byte cap with all-or-nothing eviction"
     note for sourcedOp "An op's Device field is whatever the writer typed; From is the journal object it actually came out of, which the /store door gates. Attribution reads From — a peer cannot sign someone else's name on a change by editing its own journal"
     note for RemoteSource "OpenBlob is the single blob-read door: the sha must match blobRe, and verify re-hashes the bytes whenever the backend is a PutSigner — in direct-upload mode the server never saw the content, so the store is the only thing that could have swapped it. It stops re-hashing only once the object is PROVABLY immutable: both presign doors refuse a key that exists, so every URL for a blob was minted before its first PUT and dies at mint+PresignTTL; past that age the hub is the only writer left. That is what remote.Object.Modified is for"
     class Uploader {
@@ -369,6 +379,7 @@ classDiagram
     DeviceRegistry ..> DeviceInfo
     DeviceRegistry *-- devKey : (account, id)
     RemoteSource ..> sourcedOp : attribution comes from the journal key
+    RemoteSource *-- cachedJournal : parsed ops, keyed on size+mtime
     ReadLedger ..> ReadStat
     ReadLedger ..> HeatEntry
     QuotaProvider <|.. UnlimitedQuota

--- a/internal/webapp/journalcache_test.go
+++ b/internal/webapp/journalcache_test.go
@@ -1,0 +1,232 @@
+package webapp
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/runbear-io/beardrive/internal/remote"
+)
+
+// History folded every journal of a project on EVERY request — 8-10s on a real
+// project, and paging made it worse rather than better, since each "load more"
+// re-downloaded and re-parsed the lot (BEA-85). Journals only grow, so the
+// (Size, Modified) that List already reports proves a parse is still current.
+//
+// These tests pin the cache from the outside: what matters is not that a map
+// exists but that a warm request touches no journal bytes, and that the feed it
+// produces is the one the uncached code produced.
+
+// countBackend counts the reads and lists the hub makes through it, per key.
+type countBackend struct {
+	remote.Backend
+	mu    sync.Mutex
+	gets  map[string]int
+	lists int
+}
+
+func newCountBackend(be remote.Backend) *countBackend {
+	return &countBackend{Backend: be, gets: map[string]int{}}
+}
+
+func (b *countBackend) Get(ctx context.Context, key string) (io.ReadCloser, error) {
+	b.mu.Lock()
+	b.gets[key]++
+	b.mu.Unlock()
+	return b.Backend.Get(ctx, key)
+}
+
+func (b *countBackend) List(ctx context.Context, prefix string) ([]remote.Object, error) {
+	b.mu.Lock()
+	b.lists++
+	b.mu.Unlock()
+	return b.Backend.List(ctx, prefix)
+}
+
+// journalGets is how many times a journal — any journal — has been fetched.
+func (b *countBackend) journalGets() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	n := 0
+	for k, c := range b.gets {
+		if strings.Contains(k, "journal/") {
+			n += c
+		}
+	}
+	return n
+}
+
+func (b *countBackend) getsFor(dev string) int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	n := 0
+	for k, c := range b.gets {
+		if strings.HasSuffix(k, "journal/"+dev+".jsonl") {
+			n += c
+		}
+	}
+	return n
+}
+
+func (b *countBackend) listCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.lists
+}
+
+// cachedHub is a hub over a counting backend with a seeded three-device
+// project, plus the handler and the base URL for its history route.
+func cachedHub(t *testing.T) (*Server, *countBackend, *fakeRemote, http.Handler, string) {
+	t.Helper()
+	var cb *countBackend
+	srv, p, root := newHub(t, false, func(be remote.Backend) remote.Backend {
+		cb = newCountBackend(be)
+		return cb
+	})
+	f := newFakeRemoteAt(t, filepath.Join(root, p.ID))
+	f.putAs("dev1", "alice@x.io", "Alice", "notes/plan.md", "v1")
+	f.putAs("dev1", "alice@x.io", "Alice", "notes/plan.md", "v2 longer")
+	f.putAs("dev2", "bob@x.io", "Bob", "notes/other.md", "bob's file")
+	f.del("dev2", "notes/other.md")
+	f.putAs("dev3", "carol@x.io", "Carol", "readme.md", "top")
+	return srv, cb, f, srv.Handler(), "/api/p/" + p.ID + "/"
+}
+
+func TestHistoryReusesParsedJournals(t *testing.T) {
+	_, cb, _, h, base := cachedHub(t)
+
+	if rec := do(t, h, "GET", base+"history", nil); rec.Code != 200 {
+		t.Fatalf("cold history: %d %s", rec.Code, rec.Body)
+	}
+	cold, lists := cb.journalGets(), cb.listCount()
+	if cold < 3 {
+		t.Fatalf("cold load fetched %d journals, want at least 3", cold)
+	}
+
+	for i := 0; i < 3; i++ {
+		if rec := do(t, h, "GET", base+"history", nil); rec.Code != 200 {
+			t.Fatalf("warm history: %d %s", rec.Code, rec.Body)
+		}
+	}
+	if got := cb.journalGets(); got != cold {
+		t.Fatalf("warm requests fetched %d journals, want 0 beyond the cold %d", got-cold, cold)
+	}
+	// The List is the round trip a warm request still pays: it is what proves
+	// nothing changed, so it must NOT be cached away.
+	if cb.listCount() <= lists {
+		t.Fatalf("list count %d did not advance past %d", cb.listCount(), lists)
+	}
+}
+
+func TestJournalCacheInvalidatesOnePush(t *testing.T) {
+	_, cb, f, h, base := cachedHub(t)
+	do(t, h, "GET", base+"history", nil)
+	before1, before2, before3 := cb.getsFor("dev1"), cb.getsFor("dev2"), cb.getsFor("dev3")
+
+	f.putAs("dev2", "bob@x.io", "Bob", "notes/other.md", "bob is back")
+	if rec := do(t, h, "GET", base+"history", nil); rec.Code != 200 {
+		t.Fatalf("history after push: %d %s", rec.Code, rec.Body)
+	}
+	if got := cb.getsFor("dev2"); got != before2+1 {
+		t.Fatalf("dev2 fetched %d times, want %d", got, before2+1)
+	}
+	if cb.getsFor("dev1") != before1 || cb.getsFor("dev3") != before3 {
+		t.Fatalf("untouched journals re-fetched: dev1 %d→%d, dev3 %d→%d",
+			before1, cb.getsFor("dev1"), before3, cb.getsFor("dev3"))
+	}
+}
+
+func TestJournalCachePagingRefetchesNothing(t *testing.T) {
+	_, cb, _, h, base := cachedHub(t)
+
+	rec := do(t, h, "GET", base+"history?n=2", nil)
+	if rec.Code != 200 {
+		t.Fatalf("page 1: %d %s", rec.Code, rec.Body)
+	}
+	var page struct {
+		Entries []HistoryEntry `json:"entries"`
+		Next    string         `json:"next_cursor"`
+	}
+	mustJSON(t, rec, &page)
+	if page.Next == "" {
+		t.Fatalf("no cursor to page with: %s", rec.Body)
+	}
+	after := cb.journalGets()
+
+	for cursor := page.Next; cursor != ""; cursor = page.Next {
+		page.Next = ""
+		mustJSON(t, do(t, h, "GET", base+"history?n=2&cursor="+url.QueryEscape(cursor), nil), &page)
+	}
+	if got := cb.journalGets(); got != after {
+		t.Fatalf("paging re-fetched %d journals", got-after)
+	}
+}
+
+// The criterion that matters most: the cache must be invisible in the output.
+func TestHistoryOutputUnchangedByCache(t *testing.T) {
+	srv, _, _, h, base := cachedHub(t)
+	urls := []string{
+		"history", "history?path=notes/plan.md", "history?prefix=notes",
+		"history?n=2", "history?user=alice@x.io",
+	}
+	warm := make([]string, len(urls))
+	for i, u := range urls {
+		do(t, h, "GET", base+u, nil) // cold
+		warm[i] = do(t, h, "GET", base+u, nil).Body.String()
+	}
+
+	// Drop everything the cache holds; the next request is the uncached code
+	// path, byte for byte.
+	_, v, err := srv.projectVolume(strings.TrimSuffix(strings.TrimPrefix(base, "/api/p/"), "/"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rs := v.source.(*RemoteSource)
+	rs.jmu.Lock()
+	rs.jcache, rs.jbytes = nil, 0
+	rs.jmu.Unlock()
+
+	for i, u := range urls {
+		if got := do(t, h, "GET", base+u, nil).Body.String(); got != warm[i] {
+			t.Fatalf("%s differs with and without the cache:\ncached: %s\nfresh:  %s", u, warm[i], got)
+		}
+	}
+}
+
+// A journal the remote no longer has must not stay resident, or a hub leaks a
+// map entry per device that ever synced anything.
+func TestJournalCacheDropsVanishedJournals(t *testing.T) {
+	srv, _, f, h, base := cachedHub(t)
+	do(t, h, "GET", base+"history", nil)
+
+	_, v, err := srv.projectVolume(strings.TrimSuffix(strings.TrimPrefix(base, "/api/p/"), "/"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rs := v.source.(*RemoteSource)
+	if err := os.Remove(filepath.Join(f.dir, "journal", "dev3.jsonl")); err != nil {
+		t.Fatal(err)
+	}
+
+	do(t, h, "GET", base+"history", nil)
+	rs.jmu.Lock()
+	defer rs.jmu.Unlock()
+	if _, ok := rs.jcache["journal/dev3.jsonl"]; ok {
+		t.Fatalf("cache kept a journal the remote no longer has: %v", rs.jcache)
+	}
+	// The running total is what the ceiling is enforced against, so a prune or
+	// a re-fetch that forgets to subtract would quietly disable the cache.
+	var sum int64
+	for _, c := range rs.jcache {
+		sum += c.bytes
+	}
+	if rs.jbytes != sum {
+		t.Fatalf("byte total %d, cached entries sum to %d", rs.jbytes, sum)
+	}
+}

--- a/internal/webapp/server.go
+++ b/internal/webapp/server.go
@@ -38,6 +38,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/runbear-io/beardrive/internal/journal"
 	"github.com/runbear-io/beardrive/internal/remote"
 	"github.com/runbear-io/beardrive/internal/templates"
@@ -299,7 +301,32 @@ type RemoteSource struct {
 	// sealed holds the blobs this process has verified AND proved immutable.
 	// See verify.
 	sealed sync.Map // sha (string) → struct{}
+
+	jmu    sync.Mutex               // guards jcache and jbytes
+	jcache map[string]cachedJournal // "journal/<dev>.jsonl" → parsed ops
+	jbytes int64                    // raw journal bytes currently cached
 }
+
+// cachedJournal is one journal's parsed ops plus the (size, modified) that
+// proves the parse is still current. See loadSourcedOps.
+type cachedJournal struct {
+	size  int64
+	mod   time.Time
+	bytes int64 // raw bytes this entry stands for, for the ceiling
+	ops   []journal.Op
+}
+
+// journalFetchConcurrency bounds the parallel journal fetches on a cold load.
+// A cache can never help a first request, and that loop is one serial round
+// trip to S3 per device that has ever synced the project.
+const journalFetchConcurrency = 8
+
+// ponytail: a per-project raw-byte cap with all-or-nothing eviction, so the
+// real ceiling is maxCachedJournalBytes x the number of projects a hub has
+// touched since start — s.vols never evicts. Closing it properly means one
+// budget shared across RemoteSources with LRU, or reading only the appended
+// tail of each journal, which makes the cache small in the first place.
+const maxCachedJournalBytes = 64 << 20
 
 // OpenBlob is the one way a blob's bytes leave the hub, and on a hub whose
 // storage can presign it is also the only place left that can tell a content
@@ -436,35 +463,120 @@ type sourcedOp struct {
 	From string
 }
 
+// loadSourcedOps folds every journal on the remote into one slice of ops. It
+// is the funnel every reader goes through — history, folder listings, restore,
+// and the hub's own appendOp — so re-downloading and re-parsing every journal
+// here was the whole cost of a history page, paid again per "load more".
+//
+// Journals only ever GROW: a device appends only to its own (the one-writer
+// invariant) and the hub's appendOp rewrites its key with strictly more bytes.
+// Nothing shrinks or rewrites one in place, so the (Size, Modified) that List
+// already reports proves a parse we still hold is current — no staleness
+// window, no time-based expiry, and no new Backend method. The List is the one
+// round trip every request still pays.
+//
+// No singleflight: two requests that miss the same journal at the same moment
+// both fetch it, which is what every request did before this existed.
 func (r *RemoteSource) loadSourcedOps(ctx context.Context) ([]sourcedOp, error) {
 	objs, err := r.Backend.List(ctx, "journal/")
 	if err != nil {
 		return nil, fmt.Errorf("list journals: %w", err)
 	}
-	var all []sourcedOp
+	keep := make([]remote.Object, 0, len(objs))
 	for _, o := range objs {
-		if !strings.HasSuffix(o.Key, ".jsonl") {
+		if strings.HasSuffix(o.Key, ".jsonl") {
+			keep = append(keep, o)
+		}
+	}
+
+	parsed := make([][]journal.Op, len(keep))
+	var misses []int
+	r.jmu.Lock()
+	// Pruning here rather than after the fetch: a journal that VANISHED is a
+	// pass with no misses at all, so a prune on the store path would never see
+	// it and the entry would stay resident for the life of the process.
+	live := make(map[string]bool, len(keep))
+	for i, o := range keep {
+		live[o.Key] = true
+		if c, ok := r.jcache[o.Key]; ok && c.size == o.Size && c.mod.Equal(o.Modified) {
+			parsed[i] = c.ops
 			continue
 		}
-		rc, err := r.Backend.Get(ctx, o.Key)
-		if err != nil {
-			return nil, fmt.Errorf("fetch %s: %w", o.Key, err)
+		misses = append(misses, i)
+	}
+	for k, c := range r.jcache {
+		if !live[k] {
+			r.jbytes -= c.bytes
+			delete(r.jcache, k)
 		}
-		data, err := io.ReadAll(rc)
-		rc.Close()
-		if err != nil {
+	}
+	r.jmu.Unlock()
+
+	if len(misses) > 0 {
+		sizes := make([]int64, len(keep))
+		g, gctx := errgroup.WithContext(ctx)
+		g.SetLimit(journalFetchConcurrency)
+		for _, i := range misses {
+			g.Go(func() error {
+				rc, err := r.Backend.Get(gctx, keep[i].Key)
+				if err != nil {
+					return fmt.Errorf("fetch %s: %w", keep[i].Key, err)
+				}
+				data, err := io.ReadAll(rc)
+				rc.Close()
+				if err != nil {
+					return err
+				}
+				sizes[i] = int64(len(data))
+				// A corrupt journal is ignored rather than breaking the view —
+				// and cached as zero ops, or it is re-downloaded on every
+				// request for as long as it stays corrupt.
+				if ops, err := journal.Parse(data); err == nil {
+					parsed[i] = ops
+				}
+				return nil
+			})
+		}
+		if err := g.Wait(); err != nil {
 			return nil, err
 		}
-		ops, err := journal.Parse(data)
-		if err != nil {
-			continue // corrupt journal; ignore rather than break the view
-		}
+		r.cacheJournals(keep, misses, parsed, sizes)
+	}
+
+	// A fresh outer slice on every call: handleHistory and Files both sort what
+	// they are handed, and the cached ops must never be the thing they reorder.
+	// journal.Op is all value fields, so appending one copies it.
+	var all []sourcedOp
+	for i, o := range keep {
 		from := strings.TrimSuffix(strings.TrimPrefix(o.Key, "journal/"), ".jsonl")
-		for _, op := range ops {
+		for _, op := range parsed[i] {
 			all = append(all, sourcedOp{Op: op, From: from})
 		}
 	}
 	return all, nil
+}
+
+// cacheJournals records what the fetch pass parsed, and enforces the byte
+// ceiling by dropping everything — a cold pass costs what every pass cost
+// before this cache existed, so the fallback is today's behavior, not an error.
+func (r *RemoteSource) cacheJournals(keep []remote.Object, misses []int, parsed [][]journal.Op, sizes []int64) {
+	r.jmu.Lock()
+	defer r.jmu.Unlock()
+	if r.jcache == nil {
+		r.jcache = make(map[string]cachedJournal, len(keep))
+	}
+	for _, i := range misses {
+		if c, ok := r.jcache[keep[i].Key]; ok {
+			r.jbytes -= c.bytes
+		}
+		r.jcache[keep[i].Key] = cachedJournal{
+			size: keep[i].Size, mod: keep[i].Modified, bytes: sizes[i], ops: parsed[i],
+		}
+		r.jbytes += sizes[i]
+	}
+	if r.jbytes > maxCachedJournalBytes {
+		r.jcache, r.jbytes = nil, 0
+	}
 }
 
 func (r *RemoteSource) Files(ctx context.Context) (map[string]FileInfo, error) {


### PR DESCRIPTION
## TL;DR

* History took 8–10s because every request downloaded **every journal in the project** and re-parsed **every op ever written** — and each "load more" paid it again, which is why pagination made it worse rather than better.
* No index was ever going to help: journals live in object storage, never in the DB.
* Journals only ever grow, so the `(size, mtime)` that `List` already returns proves a cached parse is still good. A warm request now does one `List` and zero downloads.
* Cold loads got faster too — the journal fetches run concurrently instead of one serial round trip per device.
* Known gap: the reporter's real project is unmeasured. Local numbers below; if the cold path is still slow there, the next step is tail-reads, not a looser target.

## What was actually slow

```mermaid
flowchart LR
    R["every request"] --> L["List journal/"]
    L --> G["Get EVERY journal<br/>one at a time"]
    G --> P["parse EVERY op<br/>ever written"]
    P --> S["sort twice,<br/>slice one page"]
    classDef hot fill:#ef444422,stroke:#ef4444,stroke-width:2px
    class G,P hot
```

`loadSourcedOps` is the funnel every reader goes through — history, folder listings, restore, and the hub's own `appendOp` — and it cached nothing. A cursor is a position in an ordering, not a snapshot, so paging re-loaded everything and skipped forward in memory.

## What it does now

```mermaid
flowchart LR
    R["every request"] --> L["List journal/<br/>one round trip, always"]
    L --> C{"size + mtime<br/>unchanged?"}
    C -- hit --> U["reuse the parsed ops"]
    C -- miss --> F["Get + parse<br/>concurrently, limit 8"]
    U --> A["fresh outer slice<br/>callers sort it"]
    F --> A
    classDef good fill:#22c55e22,stroke:#22c55e,stroke-width:2px
    class U,F good
```

The enabling fact is already load-bearing elsewhere in the repo: **journals only grow.** A device appends only to its own (the one-writer invariant) and the hub's `appendOp` is a read-modify-write that rewrites the key with strictly more bytes. Nothing shrinks or rewrites one in place, so a matching `(Size, Modified)` proves the parse we hold is current — no staleness window, no time-based expiry, and no new `Backend` method. All three real backends report both fields.

`Files()` needed no change: it goes through the same funnel, so folder listings get the cache for free. Please don't add a second cache next to `volume.snapshot`.

## Numbers

Measured locally with a throwaway test (not committed): 16 000 ops across 8 journals, behind a backend with a simulated 40 ms round trip.

| | cold | warm |
| -- | -- | -- |
| before | 465 ms | 467 ms — every request identical, which is the reported symptom |
| after | 124 ms | 54 ms |

The warm request is now the `List` plus assembly. **The 1s target in the issue is inferred, not given, and the reporter's real project is unmeasured** — if the cold path there is still slow, that's the signal to do the tail-read step rather than loosen the number.

## What can't break

* **Output is byte-identical.** `TestHistoryOutputUnchangedByCache` captures `/history` across five query shapes warm, drops the cache, and compares byte for byte — ordering, cursors, `add`/`edit`/`delete` classification and the device-registry join all unchanged. Ops are assembled in the same `List` order the old loop used, which matters because both downstream sorts are `SliceStable`.
* **Callers still sort what they're handed.** Every call assembles a fresh outer slice; the cached `[]journal.Op` is never handed out directly, or the first sort would scramble the cache. `journal.Op` is all value fields, so appending one copies it.
* **A corrupt journal is still ignored** — and now cached as zero ops, or it would be re-downloaded on every request for as long as it stays corrupt.
* **`appendOp` reads through the same cache** while holding `upmu` and computes `maxLamport`/`mySeq` from what it reads. Safe because invalidation is by `(size, mtime)` and it re-`List`s inside the lock, so it sees its own previous write. Deliberately no "skip the cache for writes" shortcut — that would reintroduce the serial fetch on the upload path.

## What you're accepting

* **Memory.** What was transient per request is now resident. Peak per request is unchanged; the new cost is that it persists, across every project the hub has served since start (`s.vols` never evicts). Bounded at 64 MiB of raw journal bytes per project with all-or-nothing eviction — over the cap it drops everything and that pass costs exactly what every pass cost before. The real ceiling is that times the number of projects touched, named in a `ponytail:` comment with the upgrade path.
* **No singleflight.** Two requests missing the same journal at the same moment both fetch it — which is what *every* request did before this existed.
* **`Modified` granularity on `file://`** is coarse on some filesystems. Size is the primary token and always changes on append; the mtime pairing is belt-and-braces.

## Deviation from the plan

One, small: the plan pruned vanished journals in the store pass. That pass only runs when something was fetched, so a journal that *disappeared* would never be seen and its entry stayed resident forever. Pruning moved into the partition pass, which runs on every request. `TestJournalCacheDropsVanishedJournals` pins it.

## Architecture changes

`architecture/webapp-server.md`: `RemoteSource` gained the cache fields (`jcache`, `jbytes`) and `cacheJournals`; new value type `cachedJournal` composed into it. Nothing removed.

> ✅ added · ❌ removed (strikethrough) · unmarked = unchanged

```mermaid
flowchart TB
    RemoteSource["<div style='text-align:left'><b>RemoteSource</b><br/>+Backend remote.Backend<br/>+Device Identity<br/>+PresignTTL time.Duration<br/>+Remove(ctx, path, who, note)<br/>+OpenBlob(ctx, sha)<br/>-verify(ctx, sha) re-hash until sealed<br/>-blobStat(ctx, blob) remote.Object<br/>-sealed sync.Map sha→proved immutable<br/><span style='background:#22c55e55;padding:0 4px;border-radius:3px'>✅ -jcache map key→cachedJournal</span><br/><span style='background:#22c55e55;padding:0 4px;border-radius:3px'>✅ -jbytes int64 raw bytes cached</span><br/>-loadSourcedOps(ctx) []sourcedOp<br/><span style='background:#22c55e55;padding:0 4px;border-radius:3px'>✅ -cacheJournals(keep, misses, parsed, sizes)</span><br/>-appendOp(ctx, op)</div>"]
    sourcedOp["<div style='text-align:left'><b>sourcedOp</b><br/>+Op journal.Op<br/>+From journal key's device</div>"]
    cachedJournal["<div style='text-align:left'><b>cachedJournal</b><br/>+size int64<br/>+mod time.Time<br/>+bytes int64<br/>+ops []journal.Op</div>"]
    Why["Journals only GROW, so List's<br/>size + mtime is a free version token.<br/>No expiry, no new Backend method.<br/>Bounded by a raw-byte cap per project."]
    RemoteSource -. "attribution comes from the journal key" .-> sourcedOp
    RemoteSource -- "<span style='background:#22c55e55;padding:0 5px;border-radius:3px'>✅ parsed ops, keyed on size+mtime</span>" --> cachedJournal
    cachedJournal -.- Why
    classDef added fill:#22c55e22,stroke:#22c55e,stroke-width:2px
    classDef noteBox fill:#88888822,stroke:#888888,stroke-dasharray:2 2
    class cachedJournal added
    class Why noteBox
    linkStyle 1 stroke:#22c55e,stroke-width:2px
```

## What was run

* `go build ./...`, `go vet ./...` — clean
* `go test ./...` — all packages pass
* `go test -race -timeout 40m ./internal/webapp/` — clean (23 min; it needs the longer timeout because unrelated slow tests blow past Go's 10m default)
* `npm run e2e` — 153 passed, 1 skipped (the skip is pre-existing)
* New tests: `internal/webapp/journalcache_test.go` — warm request fetches zero journals, one push invalidates only that journal, paging fetches nothing further, output byte-identical with and without the cache, vanished journals are dropped and the byte total stays honest

No frontend changes, so `static/` is untouched.

Closes BEA-85.

## Build session

```
cd $(git worktree list | grep bea-85 | awk '{print $1}') && claude --resume e2d2c4c2-4810-4cba-ac69-57ee1f08a3f7
```

(only works on this machine)
