### PR TITLE
fix(cli): ask before macOS pops "Background Items Added" at init

### DIFF
--- a/cmd/bdrive/autostart_notice_test.go
+++ b/cmd/bdrive/autostart_notice_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestInstallAutostartWarnsBeforeTheFirstMacOSWrite
+//
+// Writing ~/Library/LaunchAgents/*.plist is what makes macOS pop "Background
+// Items Added". Nothing suppresses that notice, so the only thing keeping it
+// from reading as malware is our own line arriving first — and it must arrive
+// only when a write is actually about to happen, or it becomes noise every
+// init prints and nobody reads.
+func TestInstallAutostartWarnsBeforeTheFirstMacOSWrite(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("the notice exists only on macOS")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Non-interactive: no prompt, just the heads-up. (The TTY branch needs a
+	// terminal survey can drive, which a test does not have.)
+	say := func() string {
+		t.Helper()
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		old := os.Stdout
+		os.Stdout = w
+		installAutostart(false)
+		os.Stdout = old
+		w.Close()
+		out, _ := io.ReadAll(r)
+		r.Close()
+		return string(out)
+	}
+
+	first := say()
+	if !strings.Contains(first, "Background Items Added") {
+		t.Errorf("first install said nothing about the macOS notice:\n%s", first)
+	}
+	plist := filepath.Join(home, "Library", "LaunchAgents", "ai.beardrive.daemon.plist")
+	if _, err := os.Stat(plist); err != nil {
+		t.Fatalf("no agent written: %v", err)
+	}
+
+	// Already registered: no second write, so no notice to explain.
+	if second := say(); strings.Contains(second, "Background Items Added") {
+		t.Errorf("re-running warned again about a notice that will not fire:\n%s", second)
+	}
+}

--- a/cmd/bdrive/init.go
+++ b/cmd/bdrive/init.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -241,7 +242,7 @@ the folder was renamed or moved.`,
 					installAgentHooks(folder)
 				}
 				if !noAutostart {
-					installAutostart()
+					installAutostart(stdinIsTTY() && !yes)
 				}
 				return startSync(cmd.Context(), folder, proj, foreground, 3*time.Second, 10*time.Second)
 			}
@@ -387,7 +388,7 @@ the folder was renamed or moved.`,
 				installAgentHooks(folder)
 			}
 			if !noAutostart {
-				installAutostart()
+				installAutostart(interactive)
 			}
 			if len(scope) > 0 {
 				dirs := make([]string, len(scope))
@@ -493,7 +494,36 @@ func installAgentHooks(folder string) {
 // Linux without systemd) or an unwritable config dir is not a reason to fail
 // an init that otherwise worked — the folder syncs, it just won't come back by
 // itself.
-func installAutostart() {
+//
+// On macOS the write itself is what users see: the moment anything lands in
+// ~/Library/LaunchAgents, Ventura+ pops "Background Items Added", naming a
+// binary they just installed. Nothing suppresses that notice — SMAppService, a
+// System Settings login item and a real crontab all trigger it (cron also
+// wants Full Disk Access on top) — so the fix is to make it expected rather
+// than to dodge it: say what is about to happen before it happens, and on a
+// TTY ask first. Linux and Windows show nothing, so they are not asked.
+func installAutostart(interactive bool) {
+	if runtime.GOOS == "darwin" && !autostart.Installed() {
+		const notice = `macOS will show a "Background Items Added" notice for it`
+		if interactive {
+			ok := true
+			// An interrupt reads as "no": autostart is a convenience, and the
+			// caller is one step from starting the daemon anyway.
+			//
+			// ponytail: a decline is not remembered, so re-running `bdrive init`
+			// interactively asks again. Persist it in settings.json if that ever
+			// nags — agents and scripts have no TTY and never see the prompt.
+			if err := survey.AskOne(&survey.Confirm{
+				Message: "Restart syncing at login? (" + notice + ")",
+				Default: true,
+			}, &ok); err != nil || !ok {
+				fmt.Println("  login:   autostart skipped — `bdrive autostart install` enables it later")
+				return
+			}
+		} else {
+			fmt.Println("  login:   registering sync to restart at login — " + notice)
+		}
+	}
 	res, err := autostart.Install()
 	if err != nil {
 		if !errors.Is(err, autostart.ErrUnsupported) {

--- a/web/docs/src/content/docs/manual/hooks.md
+++ b/web/docs/src/content/docs/manual/hooks.md
@@ -110,6 +110,15 @@ Linux needs systemd as the init system. Without it — Alpine or another
 runit/OpenRC distro, WSL1, a slim container — `bdrive autostart` says so rather
 than writing a unit nothing would read.
 
+On macOS, the moment that file is written you get a **"Background Items Added"**
+notification, and `bdrive` appears in System Settings → General → Login Items.
+That notice is macOS reporting the registration above — every way of starting
+at login triggers it, including Apple's own `SMAppService` and a plain
+`crontab` — so `bdrive init` asks first on a terminal and says what is about to
+happen when it can't ask. Answer no, or run `bdrive autostart uninstall`, and
+the item goes away; sync then resumes on the next `bdrive resume`, `bdrive
+init`, or agent turn instead of at login.
+
 On Windows you may see a console window flicker at logon: bdrive is a console
 program and `resume` exits in milliseconds. Nothing is wrong.
 


### PR DESCRIPTION
## TL;DR

- Setting up BearDrive on a Mac pops a **"Background Items Added"** notification naming `bdrive`, with zero context — it reads as malware, not as the login item you just asked for.
- `bdrive init` now asks first on a terminal, and says what is about to happen when there's no terminal to ask in.
- No new state, no new flag — `--no-autostart` already existed, and declining just points at `bdrive autostart install`.
- macOS only: the systemd user unit and the Windows Run entry show the user nothing.
- **Known gap:** in the agent paste-prompt flow the agent always passes `--yes`, so the explanation lands in a collapsed tool result the human likely never expands. Closing that is a runbook change (`INSTALL_FOR_AGENTS.md` + the `beardrive:install` skill), not in this PR.

## Why the notice can't just be suppressed

Ventura+ fires it the moment anything lands in `~/Library/LaunchAgents`, and every alternative trips the same thing: `SMAppService`, a System Settings login item, and a real `crontab` — which additionally wants Full Disk Access for `/usr/sbin/cron`, trading one notification for a TCC prompt. There is no API that opts out. So the fix is to make the notice *expected* rather than to dodge it.

The other half of "expected" is whose name is on it. Unsigned, macOS labels the item with whatever it can scrape — a raw path, or the enclosing terminal. Signed with a Developer ID it says "BearDrive". That's a `.goreleaser.yaml` change for whenever releases are signed, and is not attempted here.

## What changed

All of it in `installAutostart` (`cmd/bdrive/init.go`), which both init call sites already routed through, so the gate is written once:

| Situation | Behavior |
|---|---|
| macOS, TTY, first registration | `survey.Confirm`, default yes: *"Restart syncing at login? (macOS will show a "Background Items Added" notice for it)"*. Declining (or Ctrl-C) prints `bdrive autostart install` and moves on |
| macOS, no TTY (`--yes`, agents, scripts) | One line printed **before** the write saying the notice is coming |
| Already registered | Nothing extra — no write, so no notice will fire |
| Linux / Windows | Untouched |

An interrupt reads as "no" rather than aborting: autostart is best-effort by design, and the caller is one step from starting the daemon anyway.

A decline is deliberately not persisted, so re-running `bdrive init` on a TTY asks again — marked with a `ponytail:` comment naming the settings.json flag to add if it ever nags. Agents and scripts have no TTY and never see the prompt, so the nag surface is one interactive re-init.

## Tests

`cmd/bdrive/autostart_notice_test.go` asserts the notice appears on the first write and *not* on the second (skipped off darwin). Mutation-checked by dropping the `!autostart.Installed()` guard — the test fails as intended. `go vet ./...` clean, `go test ./cmd/bdrive/` passes.

## Docs

`web/docs/.../manual/hooks.md` gains a paragraph next to the existing Windows console-flicker note, in the same "you'll see X, nothing is wrong" shape. README's console sample is left alone: it already abridges the interactive project-choice prompts, so showing one prompt and not the others would be worse than showing none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dHmCQSpn6WgkqFG62umK4