### PR TITLE
docs: three claims that no longer match the code

### DIFF
--- a/web/docs/src/content/docs/guides/shared-agent-memory.md
+++ b/web/docs/src/content/docs/guides/shared-agent-memory.md
@@ -73,7 +73,7 @@ A dedicated folder with no enclosing repository needs only the synced
 `AGENTS.md`. At the mount root, every platform loads it at session start.
 :::
 
-`/beardrive:install` offers to write both files, each as its own consent. Never
+Ask your agent to write them and it will offer each as its own consent. Never
 write either silently into someone's repository.
 
 ## The orientation ritual

--- a/web/docs/src/content/docs/index.md
+++ b/web/docs/src/content/docs/index.md
@@ -87,4 +87,4 @@ You need a hub to sync through. Two ways to get one:
 GNU AGPL-3.0. Everything in the repository is open source and self-hostable — a
 complete BearDrive server for one organization's deployment, teams included. The
 managed service at beardrive.ai is the same core plus what only makes sense as
-an operated service: hosting, SSO, billing and plan quotas, backups, support.
+an operated service: hosting, billing and plan quotas, backups, support.

--- a/web/docs/src/content/docs/start/setup.md
+++ b/web/docs/src/content/docs/start/setup.md
@@ -33,7 +33,7 @@ Starting from nothing (no project id, no name), it recommends `shared/` and
 names the new project `shared`.
 
 If the folder turns out to be empty once it is connected, the agent offers one
-more choice: start from a structure, or from scratch. Three are shipped:
+more choice: start from a structure, or from scratch. Four are shipped:
 
 - **Docs + decision records** (`docs/`, `decisions/`) — the boring default, and
   the one to take if you are not sure.


### PR DESCRIPTION
## TL;DR

- The setup page says three project templates ship. Four do.
- A guide tells readers to run `/beardrive:install`, which does not exist.
- The docs home lists SSO as part of the managed service. It isn't built.

## Detail

**`start/setup` — "Three are shipped" above four bullets.** `internal/templates/files/` holds `docs`, `para`, `skills` and `wiki`, and the page lists all four. Only the number was wrong.

**`guides/shared-agent-memory` — `/beardrive:install`.** There is no plugin and no skill; the integration is `internal/agenthooks`, and setup is the paste on `start/setup`. Same claim was just removed from the landing page in beardrive-cloud#32 — this is the last copy of it. Replaced with asking the agent, which is what actually happens.

**`index` — SSO.** No SAML/OIDC anywhere in either repo, and the cloud plan has it unstarted. Dropped from the list; hosting, billing, quotas, backups and support are all real.

Found while auditing the landing page against the code. Docs build clean (27 pages).

# skip-diagram-check