### PR TITLE
ci(docs): docs.beardrive.ai deploys itself again

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,72 @@
+# Builds web/docs on every PR that touches it, and deploys to Cloudflare Pages
+# (project `beardrive-docs`, custom domain docs.beardrive.ai) on push to main.
+#
+# Deliberately NOT the Pages Git integration: that clones shallow, and the
+# sitemap's <lastmod> comes from each page's commit date, so a depth-1 checkout
+# silently drops every lastmod. Hence `fetch-depth: 0` below.
+#
+# Needs two secrets: CLOUDFLARE_API_TOKEN (an account API token with
+# "Cloudflare Pages: Edit") and CLOUDFLARE_ACCOUNT_ID.
+name: docs
+on:
+  push:
+    branches: [main]
+    paths:
+      - "web/docs/**"
+      # The palette is generated from the hub frontend's tokens, so a change
+      # there changes the built docs too.
+      - "internal/webapp/frontend/src/tw.css"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    paths:
+      - "web/docs/**"
+      - "internal/webapp/frontend/src/tw.css"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # sitemap <lastmod> comes from commit dates
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/docs/package-lock.json
+
+      # The build reads ../../internal/webapp/frontend/src/tw.css, so the whole
+      # repo has to be checked out — not just this subdirectory.
+      - run: npm ci
+        working-directory: web/docs
+      - run: npm run build
+        working-directory: web/docs
+
+      - name: Deploy to Cloudflare Pages
+        if: github.event_name != 'pull_request'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: >
+          npx --yes wrangler@4 pages deploy dist
+          --project-name=beardrive-docs
+          --branch=main
+          --commit-dirty=true
+        working-directory: web/docs
+
+      # Same checks Search Console runs: robots.txt -> index -> every URL 200s.
+      # Reports, never blocks: half of what it checks (a managed robots.txt
+      # shadowing ours, cache propagation) is Cloudflare's call, not this
+      # repo's, and a good deploy must not go red over it. Read the step.
+      - name: Verify what production actually serves
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
+        run: npm run check:sitemap https://docs.beardrive.ai
+        working-directory: web/docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ npm run e2e        # Playwright suite against the seeded e2e hub (starts itself 
 ./check-dist.sh    # verify committed static/ matches frontend/src (run before releases)
 ```
 
-There is no Makefile, linter config, or CI config in-repo. Releases run `goreleaser release` on a tagged commit (see `.goreleaser.yaml`); the version is injected via `-ldflags "-X main.version=..."` into `cmd/bdrive/main.go`. The frontend's built assets are **committed** (go:embed needs them in the module), so `go build` and `go install` never require Node — but a release tag must not ship a stale `internal/webapp/static`: run `frontend/check-dist.sh` first.
+There is no Makefile or linter config in-repo. CI is three GitHub Actions workflows: `ci.yml` (build/vet/test on Linux and macOS), `bump-cloud.yml` (pins the new OSS commit in the private cloud repo), and `docs.yml` (builds `web/docs` on PRs, deploys it to the `beardrive-docs` Cloudflare Pages project — docs.beardrive.ai — on pushes to main; see `web/docs/README.md`). Releases run `goreleaser release` on a tagged commit (see `.goreleaser.yaml`); the version is injected via `-ldflags "-X main.version=..."` into `cmd/bdrive/main.go`. The frontend's built assets are **committed** (go:embed needs them in the module), so `go build` and `go install` never require Node — but a release tag must not ship a stale `internal/webapp/static`: run `frontend/check-dist.sh` first.
 
 When testing the CLI manually, set `BDRIVE_HOME=/some/tmp/dir` to relocate all beardrive state (device identity, mount registry, volume stores) away from the real `~/.bdrive`.
 

--- a/web/docs/README.md
+++ b/web/docs/README.md
@@ -117,6 +117,19 @@ to type.
 Static output in `dist/`. Any static host works; build command `npm run build`,
 output directory `dist`, project root `web/docs`.
 
+Today that host is **Cloudflare Pages**, project `beardrive-docs`
+(`docs.beardrive.ai`), deployed by `.github/workflows/docs.yml` on every push to
+`main` that touches `web/docs/**` or the token source. It needs two repository
+secrets: `CLOUDFLARE_API_TOKEN` (an account token with *Cloudflare Pages: Edit*)
+and `CLOUDFLARE_ACCOUNT_ID`.
+
+Not the Pages **Git integration**, deliberately: it clones shallow, which costs
+every `<lastmod>` (see "Checkout depth"), and it would build the docs on commits
+that cannot change them. The Pages project is a direct-upload project — nothing
+deploys it but this workflow. That is also the failure mode to watch for: when
+deploys were manual, they simply stopped, and the site sat three weeks stale
+while every check that only runs *during* a deploy stayed green.
+
 ### Redirects
 
 The docs were reorganized around the agent-first path, so three old URLs moved:


### PR DESCRIPTION
## TL;DR

- docs.beardrive.ai has been serving a **three-week-old build** (~2026-07-19, 38 docs commits behind). `/manual/hooks/` 404s, the page it replaced still serves, and #140's sitemap `<lastmod>` and `robots.txt` never shipped.
- Cause: the Cloudflare Pages project has **no Git provider** — deploys were someone running `wrangler pages deploy` by hand, and they stopped.
- New `.github/workflows/docs.yml`: builds `web/docs` on PRs that touch it, deploys to Pages on pushes to main.
- Known gap: nothing here catches "the docs went stale" in the future either — every check still only runs *during* a deploy. A weekly cron against production would, and isn't in this PR.
- Needs the `CLOUDFLARE_API_TOKEN` secret (Pages: Edit); `CLOUDFLARE_ACCOUNT_ID` is already set.

## What was wrong

| Check | Live today | At HEAD |
|---|---|---|
| `/manual/hooks/` | 404 | 200 (renamed in #85, 07-30) |
| `/manual/skills-and-hooks/` | 200, real page | meta-refresh redirect |
| `/concepts/permissions/`, `/reference/migration/` | 404 | 200 (added 07-27 / 07-23) |
| `/use-cases/shared-skills/` | 404 | 200 (#138) |
| `sitemap-0.xml` `<lastmod>` | absent | on all 27 URLs (#140) |
| `robots.txt` | Cloudflare's managed content-signals file, no `Sitemap:` | `public/robots.txt` (#140) |

Newest page present live is the use-cases set (07-19); oldest thing missing is `reference/migration` (07-23), which dates the last deploy to that window.

`wrangler pages project list` confirms it: `beardrive-docs` → `beardrive-docs.pages.dev, docs.beardrive.ai`, **Git Provider: No**, last modified two weeks ago.

## Why not the Pages Git integration

It would need no workflow at all, and it is the wrong tool twice:

1. **It clones shallow.** `astro.config.mjs` takes each page's `<lastmod>` from the commit date of the markdown behind it, so a depth-1 checkout emits none — the degradation `web/docs/README.md` already warns about under "Checkout depth". Hence `fetch-depth: 0`.
2. **It builds on every commit.** This repo is mostly Go; the docs change on a small subset of it.

The path filter includes `internal/webapp/frontend/src/tw.css` — the palette is generated from that file by `scripts/tokens.mjs`, so it is a docs input despite living outside `web/docs`. It is also why the checkout can't be sparse.

## The post-deploy check

`npm run check:sitemap https://docs.beardrive.ai` runs after deploy as `continue-on-error`. It reports; it does not gate. Half of what it asserts is Cloudflare's call rather than this repo's — a managed `robots.txt` shadowing ours fails its "robots.txt declares no Sitemap:" check, and that must not turn a good deploy red. Worth reading the step output on the first run after merge: if `robots.txt` still has no `Sitemap:` line once `public/robots.txt` is finally deployed, that's a Cloudflare setting to turn off, not a repo bug.

## Verified locally

`npm ci && npm run build` from a clean install: 27 pages, Pagefind index built, and `dist/sitemap-0.xml` carries `<lastmod>` on every URL.
