### PR TITLE
docs: "in this folder" is not an answer, and the template offer becomes a step

### DIFF
--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -118,6 +118,16 @@ the folder question in this conversation.** There is no exception — not for an
 empty folder, not for a non-repo, not for a non-interactive session. If
 you cannot ask, end your turn with the question instead of proceeding.
 
+**A location phrase in the request is not an answer.** "Set up BearDrive in
+this folder", "set this up here", "sync this project" all name *where your
+session is running* — the only place it could be — not which folder syncs.
+They are the start of this conversation, not the end of it. The question is
+answered only once the user has picked between your named recommendation and
+the alternatives you listed, in a message of their own. Treating "in this
+folder" as consent is the single most common way this step goes wrong, and it
+lands the user on the one outcome this section says never to recommend: the
+whole folder, mounted bare, chosen by you.
+
 Run init BEFORE the git handoff: init can refuse (e.g. this device already
 syncs that project somewhere else), and a refusal after you have already
 rewritten `.gitignore` and unstaged files leaves the repo half-changed. If
@@ -160,10 +170,24 @@ committed). Re-running `bdrive init --yes` later is always safe. To change
 the scope later use `bdrive scope add/rm <dir>`, never hand-edit
 `.bdrive/config.json`.
 
-**If the folder is empty after init — ask once.** Init has already pulled the
-project, so an empty folder *now* means there is genuinely nothing to build on.
-(If the project was created from a template in the browser, its files are
-already here — say nothing.) Ask: start from a structure, or from scratch?
+## 4. Offer a starting structure — **ask first**
+
+This was the last paragraph of step 3 and agents dropped it: a decision the
+user makes is not a footnote to the command before it. It is a step, and it
+runs every time the condition below holds.
+
+**Check whether the folder is empty, now that init has run.** Init has already
+pulled the project, so an empty folder *now* means there is genuinely nothing
+to build on. (If the project was created from a template in the browser, its
+files are already here — say nothing.)
+
+**Empty means no synced content, not an empty `ls -a`.** `bdrive init` just
+wrote `.bdrive/` and seeded `.bdriveignore`, so the folder is *never* literally
+empty when you look — and `.git/`, `.gitignore` and other dotfiles do not count
+either. A folder holding only those is empty for this step. Do not let the
+files init itself created talk you out of asking.
+
+Ask: start from a structure, or from scratch?
 
 > On Claude Code use `AskUserQuestion`, header "Starting point", in this
 > order: **Docs + decision records** — `docs/`, `decisions/` — labelled
@@ -182,12 +206,16 @@ pick, run one command in the same folder:
 bdrive init --template docs --yes
 ```
 
+That is a second `bdrive init` on purpose — in an already-initialized folder it
+only writes the structure and lets the normal cycle push it. Existing paths are
+never overwritten.
+
 **A folder with files in it skips this entirely.** Never offer to restructure
 someone's existing notes, and never ask before init — before init you cannot
 know whether the project already has a structure, which is how you end up with
 two copies.
 
-## 4. Confirm the sync hooks
+## 5. Confirm the sync hooks
 
 `bdrive init` already did this — do not run a separate hooks command. It
 registers turn-boundary hooks (pull before every turn, push right after
@@ -206,7 +234,7 @@ Only if a platform the user works with is missing from init's output: run
 `bdrive hooks install --agent <name>`. `bdrive hooks` shows the status table,
 `bdrive hooks uninstall` removes them again.
 
-## 5. Verify, then show the payoff
+## 6. Verify, then show the payoff
 
 Init printed the project's hub link and a sync summary — use them rather
 than running more commands. Summarize what was set up and hand the user that
@@ -217,7 +245,7 @@ fully public URLs.
 Only if something looked wrong in init's output: `bdrive status` shows the
 daemon and pending count, and `bdrive url <file>` links a specific file.
 
-## 6. Point the repo's agents at the folder — **ask first**
+## 7. Point the repo's agents at the folder — **ask first**
 
 If the synced folder sits inside a code repo (or any folder that already has a
 root `AGENTS.md` / `CLAUDE.md`), agents working from the repo root won't read


### PR DESCRIPTION
## TL;DR

- An agent told "Set up BearDrive **in this folder**" synced the whole folder without asking, and never offered a starting structure.
- Both behaviors were already written down — the ask is a hard gate in step 3, the template offer was the last paragraph of it. Neither survived contact with a real session.
- A location phrase ("in this folder", "here") is now explicitly **not** an answer to the folder question.
- The template offer is promoted from a trailing paragraph to its own step 4 — same lesson as #155.
- "Empty" is now defined, because `init` itself writes `.bdrive/` and `.bdriveignore`, so the folder is never literally empty when the agent looks.

## What happened

Reported from a real run: pasting the setup prompt in a blank folder mounted the whole folder bare — the one outcome step 3 says never to recommend — and the four templates were never offered.

Reading the runbook, both steps were there and correct. Two separate reasons they didn't fire:

**1. The request answered the question.** The landing's paste read `Set up BearDrive in this folder — follow beardrive.ai/setup`. "In this folder" names *where the session is running* — the only place it could be — but agents took it as the user having already chosen what to sync, so the gate had nothing left to gate. The paste string is fixed in the companion cloud PR; this side makes the runbook robust to any user phrasing it that way, which they will.

**2. The template offer wasn't a step.** It was the final paragraph of a 60-line step 3, after the init command, the git handoff and the permission-denial guidance. Agents finished init, reported success, and stopped. Promoting it to `## 4.` is the same fix as #155 — a decision the user makes is not a footnote to the command above it.

Also folded in: **`--template` in an already-initialized folder is deliberate**, not a mistaken second init. `cmd/bdrive/init.go:241` documents that path; the runbook never said so, which makes an agent that reads "run **one** `bdrive init`" hesitate at exactly the wrong moment.

## Defining "empty"

The step's condition was "if the folder is empty after init". It never is: `bdrive init` writes `.bdrive/config.json` and seeds `.bdriveignore` before this check runs. An agent that looks at the folder sees files. Now stated outright — those two, `.git/` and other dotfiles are not content, and "do not let the files init itself created talk you out of asking."

## Verified live, not by re-reading it

The whole failure mode here is *the doc said the right thing and the agent didn't do it*, so a doc review proves nothing. Ran the `onboarding-e2e` skill against a seeded hub with a real headless `claude -p` session, using the failing wording verbatim and no project id:

**Turn 1** — `Set up BearDrive in this folder — follow <runbook> (hub: …)`

> `bdrive` is installed, and this folder is empty. Before I run `bdrive init` I need two answers (the runbook forbids running it until you've picked the folder) … **Recommended:** create `shared/` here and sync that

`ls -a` after turn 1: still empty. Init not run. Hard gate held despite "in this folder".

**Turn 2** — "Go with your recommendation."

> The folder has no content yet (**only init's own `.bdrive/` + `.bdriveignore`**). Want a starting structure? … 1. Docs + decision records *(recommended)* 2. LLM wiki 3. PARA 4. Start from scratch

That parenthetical is the new "empty" definition doing its job — the old wording is exactly what would have kept it silent.

**Turn 3** — "Docs." → template seeded and pushed.

Final state independently verified, not taken from the transcript:
- mount is `shared/`, parent has no `.bdrive/`
- `AGENTS.md`, `docs/README.md`, `decisions/0001-record-decisions.md` present on the hub via authenticated `/api/tree`

Docs-only change; no types or relationships moved, so no architecture diagram section.
