### PR TITLE
docs: the starting paste is one sentence, not a template to fill in

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,22 +133,27 @@ No terminal needed: start any agent (Claude Code, Codex, Gemini CLI, Hermes)
 in the folder you want synced and give it one paste:
 
 ```
-Follow https://raw.githubusercontent.com/runbear-io/beardrive/main/INSTALL_FOR_AGENTS.md
-to set up BearDrive project <project-id> on <hub-url>. Ask me which folder to
-sync (the project is named "<project-name>").
+Follow beardrive.ai/setup to set up BearDrive. Ask me which folder to sync.
 ```
 
-Joining a teammate's project? They can copy that paste with the hub URL and
-project id already filled in from the project's home page in the web UI.
-Starting fresh, drop the trailing sentence — the agent recommends `shared/`
-and names the new project `shared`.
+Keep the second sentence. Without it an agent reads the first as permission to
+decide for you, and the usual guess is *this whole folder* — the one answer the
+runbook tells it never to recommend. With it, you get a named recommendation to
+accept or override: `shared/` from a standing start, or a notes folder it
+already found.
 
-The agent fetches [INSTALL_FOR_AGENTS.md](INSTALL_FOR_AGENTS.md) and follows
-it: install the CLI, then one `bdrive init` — which signs in (an approval link
-when there is no local browser), registers the sync hooks, and prints the
-project link. The instructions live at that URL rather than inside the prompt
-so they never go stale in someone's copy, and the agent handles every
-deviation (already installed, no Homebrew, sign-in, wrong folder).
+Self-hosting? Say where: `… to set up BearDrive on https://hub.example.com.`
+Joining a teammate's project? Use the paste on that project's home page in the
+web UI instead — it carries the hub URL and project id, so the agent joins the
+project rather than creating a second one beside it.
+
+`beardrive.ai/setup` redirects to [INSTALL_FOR_AGENTS.md](INSTALL_FOR_AGENTS.md),
+which the agent fetches and follows: install the CLI, then one `bdrive init` —
+which signs in (an approval link when there is no local browser), registers the
+sync hooks, and prints the project link. The instructions live at that URL
+rather than inside the prompt so they never go stale in someone's copy, and the
+agent handles every deviation (already installed, no Homebrew, sign-in, wrong
+folder).
 
 Those hooks are the whole integration, and `bdrive init` registers them in
 each platform's user config (`~/.claude/settings.json` and friends), once per

--- a/web/docs/src/content/docs/start/setup.md
+++ b/web/docs/src/content/docs/start/setup.md
@@ -15,22 +15,35 @@ Start the agent — Claude Code, Cowork, Codex, Gemini CLI, Hermes — in the fo
 you want synced, and paste:
 
 ```
-Follow https://raw.githubusercontent.com/runbear-io/beardrive/main/INSTALL_FOR_AGENTS.md
-to set up BearDrive project <project-id> on <hub-url>. Ask me which folder to
-sync (the project is named "<project-name>").
+Follow beardrive.ai/setup to set up BearDrive. Ask me which folder to sync.
 ```
 
-The agent fetches that page and works through it — install the CLI, sign in
-(it prints a link you approve in the browser), connect the project, register
-the sync hooks. You copy one
-thing; the agent handles every deviation — already installed, no Homebrew,
-browser sign-in, wrong folder. On BearDrive Cloud, drop `on <hub-url>` —
-sign-in defaults to beardrive.ai.
+`beardrive.ai/setup` redirects to
+[INSTALL_FOR_AGENTS.md](https://github.com/runbear-io/beardrive/blob/main/INSTALL_FOR_AGENTS.md),
+the runbook the agent actually follows. It fetches that page and works through
+it — install the CLI, sign in (it prints a link you approve in the browser),
+create the project, register the sync hooks. You copy one thing; the agent
+handles every deviation — already installed, no Homebrew, browser sign-in,
+wrong folder. The instructions live at that URL rather than inside the prompt,
+so they never go stale in someone's copy.
 
-The project name is in the prompt because the agent recommends a folder of
-the same name — so `handbook` on the hub is `handbook/` on everyone's disk.
-Starting from nothing (no project id, no name), it recommends `shared/` and
-names the new project `shared`.
+**"Ask me which folder to sync" is doing real work — keep it.** Without it,
+an agent reads the rest of the sentence as permission to decide for you, and
+the usual guess is *this whole folder*, which is the one answer the runbook
+tells it never to recommend. With it, the agent stops and offers you a named
+recommendation first. Starting from nothing it suggests creating `shared/`
+and names the new project `shared`; if it finds a folder that already looks
+like notes, it suggests that one instead.
+
+**Self-hosting?** Say where: `Follow beardrive.ai/setup to set up BearDrive on
+https://hub.example.com. Ask me which folder to sync.` On BearDrive Cloud
+there is nothing to add — sign-in defaults to beardrive.ai.
+
+**Joining a project a teammate already made?** Use the pre-filled paste from
+that project's home page in the hub (see the tip below) rather than this one.
+It carries the project's id and name, so the agent joins the existing project
+instead of creating a new one — and recommends a folder named after it, so
+`handbook` on the hub is `handbook/` on everyone's disk.
 
 If the folder turns out to be empty once it is connected, the agent offers one
 more choice: start from a structure, or from scratch. Four are shipped:
@@ -59,8 +72,10 @@ The hooks step is the durable part: once they are registered, every later
 session in every folder syncs automatically, with nothing to remember.
 
 :::tip[Don't retype this for teammates]
-A project's home page in the hub shows this same paste with your hub URL and
-project id already filled in. Send people there.
+A project's home page in the hub shows a paste with your hub URL and project
+id already filled in. Send people there rather than asking them to assemble
+one — it is the difference between a teammate joining your project and a
+teammate creating a second one beside it.
 :::
 
 ## What your agent just set up


### PR DESCRIPTION
## TL;DR

- The "Set up with your agent" page opened with a paste containing three placeholders — project id, hub URL, project name — that a first-time reader doesn't have yet.
- Start is now one sentence: `Follow beardrive.ai/setup to set up BearDrive. Ask me which folder to sync.`
- Same destination (`beardrive.ai/setup` 302s to the runbook) and the same wording the landing hands out, so the two surfaces stop disagreeing about how this begins.
- The join-a-teammate's-project case keeps its placeholders and points at the hub's pre-filled paste, where they're already filled in for you.
- README carries the same paste and moves with it, per the sync rule in `CLAUDE.md`.

## What was wrong

The page's opening paste was the *teammate-joining* prompt doing double duty as the *getting-started* prompt:

```
Follow https://raw.githubusercontent.com/runbear-io/beardrive/main/INSTALL_FOR_AGENTS.md
to set up BearDrive project <project-id> on <hub-url>. Ask me which folder to
sync (the project is named "<project-name>").
```

Someone arriving at `/start/setup/` has no project id, no hub URL and no project name — they have a folder. The page then spent two paragraphs explaining which placeholders to delete. That is a form, not a start.

## What it says now

```
Follow beardrive.ai/setup to set up BearDrive. Ask me which folder to sync.
```

Nothing to substitute. The two cases that genuinely need more are called out under it rather than baked into the default:

- **Self-hosting** — `… to set up BearDrive on https://hub.example.com.`
- **Joining an existing project** — use the paste on that project's hub home page. It carries the id and name, so the agent joins your project instead of creating a second one beside it. Stated as that consequence, because the failure is silent and annoying to unpick.

## Why "Ask me which folder to sync" is now explained, not just present

It reads like politeness and isn't. Drop it and agents take the rest of the sentence as permission to decide, and the guess is *this whole folder* — the one answer `INSTALL_FOR_AGENTS.md` tells them never to recommend. That was #157, found from a real run. The page now says so in a sentence, so nobody trims it as filler.

## Checked

- `beardrive.ai/setup` verified live before shipping copy that depends on it: `302 → raw.githubusercontent.com/.../INSTALL_FOR_AGENTS.md`, final `200`.
- `npm run build` in `web/docs` clean — 20 pages, Pagefind index over 31 files.
- Built `dist/start/setup/index.html` contains the new sentence, and no page in `dist/` still carries the old raw-URL paste.

Docs + README only; no CLI or config behavior changed, so no `reference/` or `self-hosting/` updates and no architecture diagram section.
