### PR TITLE
docs: scope the plaintext-credentials claim to the server (BEA-120)

### DIFF
--- a/web/docs/src/content/docs/self-hosting/authentication.md
+++ b/web/docs/src/content/docs/self-hosting/authentication.md
@@ -9,8 +9,10 @@ whole API (web UI, uploads, project creation, device sync) needs a session; only
 `bdrive serve ./folder`, remains auth-free.
 
 Accounts are email, password, and name, kept in a file-backed registry
-(`auth.json`): bcrypt password hashes and SHA-256 token digests, atomically
-rewritten. No plaintext credentials ever touch disk.
+(`auth.json`), atomically rewritten. No plaintext credentials are stored on the
+server — passwords are bcrypt-hashed and tokens are kept as SHA-256 digests. On
+a client device, the sync token is stored at `~/.bdrive/settings.json` with
+`0600` permissions and can be revoked from that device with `bdrive logout`.
 
 ## Signup is invite-only by default
 


### PR DESCRIPTION
## TL;DR

- Our own docs promised something we don't do: "No plaintext credentials ever touch disk." The client's device token is plaintext on disk.
- The sentence was true where it sat (the server's `auth.json`) and false read on its own — which is how a security-minded self-hoster reads it.
- Now it says what the server does *and* what the client does — path, `0600`, and that `bdrive logout` revokes it — in the same passage.
- One paragraph in one file. No code, no keychain work.

## The change

```diff
 Accounts are email, password, and name, kept in a file-backed registry
-(`auth.json`): bcrypt password hashes and SHA-256 token digests, atomically
-rewritten. No plaintext credentials ever touch disk.
+(`auth.json`), atomically rewritten. No plaintext credentials are stored on the
+server — passwords are bcrypt-hashed and tokens are kept as SHA-256 digests. On
+a client device, the sync token is stored at `~/.bdrive/settings.json` with
+`0600` permissions and can be revoked from that device with `bdrive logout`.
```

Both halves of the new text were checked against the code rather than trusted:
every file under `$BDRIVE_HOME` is `0600` (`internal/config/config.go:37`), and
`bdrive logout` really does revoke server-side before clearing locally
(`DELETE /api/auth/token`, [login.go:118](cmd/bdrive/login.go:118)).

## One deviation from the plan

The plan said to drop the old sentence and paste the replacement verbatim. Done —
but the replacement re-states "bcrypt-hashed / SHA-256 digests", which the lead-in
clause already said, so pasting it verbatim left the paragraph saying the same
thing twice in two sentences. The duplicated clause was removed from the lead-in
instead. Replacement text is verbatim; every fact from the original sentence is
still there.

## Deliberately untouched

- The install page's "the folder itself never holds credentials" — true as written, and the spec names it as not-the-defect.
- Moving the client token into the OS keychain. Scored and declined this run (release signing has to exist first); this PR is only the sentence.

## Acceptance

| Check | Result |
| --- | --- |
| `grep -rn -i plaintext web/docs/src/content/docs/` | one hit, the scoped sentence |
| Same grep over `README.md`, `INSTALL_FOR_AGENTS.md` | clean |
| No code changes | 1 file changed, `.md` only |
| `npm run build` in `web/docs` | ✅ 20 pages, Pagefind index built |
| `go build ./...` / `go vet ./...` / `go test ./...` | ✅ all 12 packages pass |

No frontend or webapp change, so no `npm run e2e` and no UI evaluation pass — nothing renders differently outside this docs page.

## Build session

```
cd $(git worktree list | grep bea-120 | awk '{print $1}') && claude --resume f343886f-2dcf-4664-b4b5-a33e5f6de6cb
```

(Only works on the machine that ran the build.)
