### PR TITLE
perf: the viewer stops replaying the whole journal twice per page (BEA-179)

### DIFF
--- a/internal/journal/journal.go
+++ b/internal/journal/journal.go
@@ -89,7 +89,23 @@ func (o *Op) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &w); err != nil {
 		return err
 	}
-	*o = Op(w.opWire)
+	*o = w.op()
+	return nil
+}
+
+// op resolves a decoded wire form into an Op. It is the ONE place path_raw is
+// honored, shared by UnmarshalJSON above and by Parse, which decodes into
+// pathRaw directly instead of going through Op.UnmarshalJSON: a type carrying
+// an UnmarshalJSON method makes encoding/json walk every line TWICE, once to
+// find the value's extent and again inside the method. Replaying a hub's
+// journals is ~60k lines, where that doubling was ~3.5s of the 4.8s parse, on
+// a path every viewer request goes through.
+//
+// The rule itself must not fork between the two readers — two spellings of
+// "when does path_raw win" is exactly how the divergence below comes back —
+// so it lives here and neither caller reimplements it.
+func (w pathRaw) op() Op {
+	o := Op(w.opWire)
 	if w.PathRaw != "" {
 		// path_raw is only ever the byte-exact SOURCE of the path field, so it
 		// is applied only when it re-encodes to the path the line already
@@ -102,7 +118,7 @@ func (o *Op) UnmarshalJSON(data []byte) error {
 			o.Path = string(raw)
 		}
 	}
-	return nil
+	return o
 }
 
 // lossy is what encoding/json does to a string that is not valid UTF-8: each
@@ -331,10 +347,13 @@ func Parse(data []byte) ([]Op, error) {
 		if len(line) == 0 {
 			continue
 		}
-		var op Op
-		if err := json.Unmarshal(line, &op); err != nil {
+		// Decoded as pathRaw, not Op: same bytes, same result (see pathRaw.op),
+		// without the second full scan an UnmarshalJSON method forces.
+		var w pathRaw
+		if err := json.Unmarshal(line, &w); err != nil {
 			continue
 		}
+		op := w.op()
 		// `null`, `{}` and any object with no kind decode without error and
 		// are not operations. They must produce no op: op COUNTS are the sync
 		// engine's cursors (pull's fresh[len(prev):], commit's seqBase), so a

--- a/internal/journal/parse_test.go
+++ b/internal/journal/parse_test.go
@@ -1,0 +1,42 @@
+package journal
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// Parse decodes each line into pathRaw directly instead of going through
+// Op.UnmarshalJSON, because a type carrying that method makes encoding/json
+// walk every line twice — most of the cost of replaying a hub's journals.
+//
+// That leaves two readers of the same bytes, and path_raw is precisely the
+// field where two readers disagreeing means one journal line naming two
+// different files (see TestSec_Op_PathRawCannotNameADifferentPathThanPath).
+// They share pathRaw.op so they cannot fork; this pins that they don't.
+func TestParseAgreesWithOpUnmarshalJSON(t *testing.T) {
+	nonUTF8 := secfx4Line(t, Op{Seq: 1, Device: "d", Kind: KindPut, Path: "caf\xff.md", Blob: "b"})
+
+	for name, line := range map[string]string{
+		"plain": `{"seq":1,"lamport":2,"time":"2026-01-01T00:00:00Z","device":"d","kind":"put","path":"a.md","blob":"b"}`,
+		"delete": `{"seq":2,"lamport":3,"time":"2026-01-01T00:00:00Z","device":"d","kind":"delete","path":"a.md"}`,
+		"path_raw round-trips": nonUTF8,
+		// path_raw naming a path the `path` field is not the lossy form of:
+		// both readers must refuse it, identically.
+		"path_raw refused": `{"seq":1,"lamport":1,"device":"peer","kind":"put","path":"notes.md","path_raw":"Li4vLi4vLmJkcml2ZS9jb25maWcuanNvbg==","blob":"b"}`,
+		"path_raw garbage": `{"seq":1,"lamport":1,"device":"peer","kind":"put","path":"notes.md","path_raw":"!!!not base64!!!","blob":"b"}`,
+	} {
+		ops, err := Parse([]byte(line + "\n"))
+		if err != nil || len(ops) != 1 {
+			t.Fatalf("%s: Parse: %v (%d ops)", name, err, len(ops))
+		}
+		var viaMethod Op
+		if err := json.Unmarshal([]byte(line), &viaMethod); err != nil {
+			t.Fatalf("%s: Op.UnmarshalJSON: %v", name, err)
+		}
+		if !reflect.DeepEqual(ops[0], viaMethod) {
+			t.Errorf("%s: the two readers of one line disagree:\n  Parse:           %+v\n  UnmarshalJSON:   %+v",
+				name, ops[0], viaMethod)
+		}
+	}
+}

--- a/internal/webapp/moves.go
+++ b/internal/webapp/moves.go
@@ -117,6 +117,14 @@ func buildMoveIndex(ops []journal.Op) moveIndex {
 	for i, c := range creates {
 		byKey[key(c)] = append(byKey[key(c)], i)
 	}
+	// Deletes bucketed the same way, for the reverse one-to-one check below:
+	// that check used to rescan EVERY delete and rebuild key(d2) per step, so
+	// a volume with n moves paid n^2 string builds — 168M of them, ~8s, on
+	// every viewer request. Same buckets, same answer, one map earlier.
+	byKeyDel := map[string][]int{}
+	for i, d := range deletes {
+		byKeyDel[key(d)] = append(byKeyDel[key(d)], i)
+	}
 	pairs := func(a, b half) bool {
 		return a.path != b.path && abs(a.at.Sub(b.at)) <= moveWindow
 	}
@@ -141,8 +149,8 @@ func buildMoveIndex(ops []journal.Op) moveIndex {
 			// ...and one-to-one the other way: two deletes claiming one
 			// create is the same ambiguity seen from the other side.
 			c, n := creates[only], 0
-			for _, d2 := range deletes {
-				if key(d2) == key(c) && pairs(c, d2) {
+			for _, j := range byKeyDel[key(c)] {
+				if pairs(c, deletes[j]) {
 					n++
 				}
 			}


### PR DESCRIPTION
## TL;DR

- Opening a file in a large project took ~12s — ~6s for the tree, ~6s again for the render. It is ~1s now.
- Two independent costs, both paid on *every* viewer API call: an accidentally quadratic loop in the rename index, and `journal.Parse` decoding every line twice.
- No behavior change. The move index is byte-identical, and a new test pins that the two journal readers still agree.
- Known gap: the hub's snapshot cache looks like it is disabled in production, so these rebuilds happen far more often than they should. That is deployed config in the private cloud repo, not this PR.

## Why the page was slow

`/tree`, `/render` and `/file` all go through `volume.snapshot()`, which replays the project's entire journal history. The project in BEA-179 is 13 device journals, 23 MB, 59,326 ops, 2,718 live files.

Measured against those real journals (loaded workstation, same machine before and after):

| phase | before | after |
| --- | --- | --- |
| `loadOps` (warm cache) | 0.11s | 0.07s |
| `journal.Sort` | 0.09s | 0.06s |
| replay | 0.08s | 0.08s |
| `buildMoveIndex` | **7.2 – 9.8s** | **0.14s** |
| **`FilesWithMoves` end to end (warm)** | **~7.5s** | **0.42s** |
| `journal.Parse` (cold, 23 MB) | 4.8s | 1.57s |

It was not the network, auth, markdown rendering or the 900 KB payload: `/heat` on the same project (the one endpoint that does not build a snapshot) answers in 0.29s, and other projects' trees answer in 0.33–0.43s.

## 1. The move index rescanned every delete

`buildMoveIndex` pairs a delete with a create to detect a rename. The forward pass buckets creates by `(device, blob)` and walks only the bucket — 3,146 comparisons total on this project. The one-to-one check the other way walked the entire `deletes` slice and rebuilt `key(d2)` inside the loop:

```go
for _, d2 := range deletes {
    if key(d2) == key(c) && pairs(c, d2) {   // key() allocates, every iteration
```

12,956 deletes × 12,956 ≈ 168M string builds per request. Bucketing the deletes the same way the creates already are makes the two loops symmetric. Same buckets, same pairing rules (same device, |Δt| ≤ 30s, first-ever put, one-to-one both ways), identical index out — verified equal on the real journals.

## 2. `journal.Parse` decoded every line twice

`journal.Op` carries a custom `UnmarshalJSON` so a `Path` that is not valid UTF-8 can ride as a base64 `path_raw` sidecar. A type with that method makes `encoding/json` walk each value twice: once to find its extent, once inside the method.

The rule itself is unchanged — only where it lives. `pathRaw.op` is now the single place `path_raw` is applied; `Op.UnmarshalJSON` calls it, and `Parse` decodes into `pathRaw` directly and calls it too.

That leaves two readers of the same bytes, and `path_raw` is precisely the field where two readers disagreeing means one journal line naming two different files (round 5, `TestSec_Op_PathRawCannotNameADifferentPathThanPath`). They share `pathRaw.op` so they cannot fork by construction; `TestParseAgreesWithOpUnmarshalJSON` pins it anyway, across a plain op, a delete, a `path_raw` that round-trips, one that must be refused, and one that is not valid base64. I confirmed the test is not vacuous: it fails when `Parse` is mutated to skip the fixup.

## Testing

- `go build ./...`, `go vet` on the touched packages: clean.
- `go test ./internal/journal` ✅ · `./internal/syncer` ✅ · `./internal/webapp` `-run 'Move|Share|Resolve'` ✅ (the directly-affected tests).
- The full `./internal/webapp` package was still running locally when this PR went up — this workstation is at load ~90 and the package times out there for reasons unrelated to this change. CI is the real check.

## Not in this PR

Two things worth a follow-up, neither a code change here:

1. **The snapshot cache appears to be off in production.** `refresh` defaults to 10s, but 8 requests over several minutes — with zero journal churn in that window — were all full rebuilds. Something sets it to `0` in the deployed hub config. With it on, most requests would skip the rebuild entirely.
2. **`volume.snapshot()` holds `v.mu` across the whole rebuild**, so concurrent calls serialize and the second one rebuilds from scratch anyway: two parallel `/tree` requests measured 6.2s and 11.4s. Much less painful now that a rebuild is sub-second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)