### PR TITLE
fix(cli): a push the hub refuses fails the command (BEA-183)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ hub's own storage, never something a syncing client points at directly:
 | `bdrive grep <pattern> [folder]` | Search the text **inside** the files a project syncs — Go RE2 regexp, or a literal with `-F`; `-i` ignores case, `-l` prints matching paths only, `-n` caps the lines printed (default 200, `0` = all). Output is `path:line: text`. Only files the project actually syncs are searched, so a `.bdriveignore` rule or a narrowed `bdrive scope` excludes a file from search exactly as it excludes it from sync; binary files are skipped. Pure local read — no daemon, no lock, no network, works offline and never blocks a sync in progress. Exit status 0 on match, 1 on none, so it composes in scripts |
 | `bdrive stale [folder]` | Find docs the code has outgrown: synced markdown (`.md`/`.markdown`) that links to a file written **after** the doc itself. Staleness here is not age — a doc goes stale when what it describes moves. Write times come from the **journal**, not `os.Stat`: materialize stamps a peer's file with this device's mtime, so on a freshly synced machine every mtime is identical and only the journal still knows. `-l` prints outgrown paths only, `-n` caps the docs printed (default 50, `0` = all). A reference that does not resolve to a file this project syncs — a URL, a `../` escape, a made-up path — is silently ignored. Pure local read — no daemon, no lock, no network. **Exit status is 0 whether or not anything is stale**: this is advisory, not a gate |
 | `bdrive forget <path>...` | Stop syncing a path *and* remove it from the hub — adds the rule to `.bdriveignore` (which syncs) and prunes in one step. Local files are never touched, here or on teammates' devices |
-| `bdrive url [path]` | Internal hub link for a file/folder (sign-in + membership required; `--sync` pushes first; no arg = project home). Computed locally |
+| `bdrive url [path]` | Internal hub link for a file/folder (sign-in + membership required; `--sync` pushes first, and warns on stderr if the hub refused that push; no arg = project home). Computed locally |
 | `bdrive share <file>` | Public URL for a synced file (`--list`, `--revoke`, `--expires`) |
 | `bdrive sync [folder]` | Run one sync cycle now. `--note <text>` stamps session context (e.g. an agent session id) onto changes — shown in `bdrive log` and hub history; keeps applying to daemon-committed changes until `--note-ttl` (default 30m) expires. A plain `bdrive sync` with no `--note` clears it, so a hand edit is never stamped with the last agent session's note. `--prune` also removes from the hub what `.bdriveignore` now excludes (files stay on disk everywhere). `--hook <label>` is agent-hook plumbing: event JSON on stdin, sync + note, gated-link formula (Claude Code hook JSON) on stdout |
 | `bdrive hooks [install\|uninstall]` | Register turn-boundary sync hooks in each agent platform's user config (Claude Code, Codex, Gemini CLI, Hermes) — pull each turn, push after edits, session-note stamping, agent-read tracking. Once per machine, covering every session; run automatically by `bdrive init`; idempotent (`--agent` overrides detection) |
@@ -440,6 +440,13 @@ this machine's device identity was never bound to your account — update
 `bdrive` and run `bdrive login` here. Project settings will show `write` and
 explain nothing. Both states are recorded only by a cycle that actually
 reached the hub, so the local-only ticks in between never revise the answer.
+
+`bdrive sync` also **exits non-zero** when the hub refused this device's
+changes. The blobs really do upload — only the journal is refused — so the
+progress line reads `uploading 11 files` and the summary reads `local
+changes: 0`, which a script, an agent, or a person skimming takes for
+success. It isn't one: nothing reached the hub, and nothing will until the
+refusal is dealt with. Being offline still exits 0; that one retries itself.
 
 Public `/s/<token>` share links are **unaffected** by any of this: they are
 anonymous by design and keep serving until revoked, so cutting someone's

--- a/cmd/bdrive/cmds.go
+++ b/cmd/bdrive/cmds.go
@@ -52,6 +52,16 @@ list in .bdrive/config.json is never pruned against either.`,
 			// both, and a session inside a mount syncs its root.
 			targets := syncTargets(folder)
 
+			// A refused push is the one failure that never self-heals: the
+			// hub said no and will keep saying no until somebody acts. Exiting
+			// 0 is what let a day of work sit unpushed and unnoticed — the
+			// progress line says "uploading 11 files" (the blobs really do
+			// upload; only the journal is refused), the summary says "local
+			// changes: 0", and a script or an agent reads that as success.
+			// Collected across targets rather than returned at the first one:
+			// the other mounts under this folder may be perfectly healthy and
+			// still want syncing.
+			var refused []string
 			syncOne := func(target string) error {
 				// Gate before openSession: hooks fire in every folder on every
 				// turn, and must never enroll this device or resume a paused
@@ -98,6 +108,9 @@ list in .bdrive/config.json is never pruned against either.`,
 				}
 				fmt.Printf("synced %s (project %q)\n", target, proj.Volume)
 				printCycle(res)
+				if res.ReadOnly || res.NoAccess {
+					refused = append(refused, target)
+				}
 				return nil
 			}
 
@@ -138,6 +151,11 @@ list in .bdrive/config.json is never pruned against either.`,
 				if err := syncOne(target); err != nil {
 					return err
 				}
+			}
+			if len(refused) > 0 {
+				return fmt.Errorf("the hub refused this device's changes for %s — nothing was pushed "+
+					"(the reason is printed above; your files are safe on this device)",
+					strings.Join(refused, ", "))
 			}
 			return nil
 		},

--- a/cmd/bdrive/sync_refused_test.go
+++ b/cmd/bdrive/sync_refused_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/runbear-io/beardrive/internal/config"
+)
+
+// A push the hub refuses must fail the command.
+//
+// BEA-183: a device whose id was never bound to its account (a token minted by
+// a CLI older than the binding gate) uploads its blobs fine and gets a 403 on
+// the journal alone. So `bdrive sync` printed "uploading 11 files (758.6 KB)",
+// then "local changes: 0", and exited 0 — for a full day, while nothing
+// reached the hub and no teammate saw the work. The summary line and the hub's
+// own reason were both already printed; what made the failure invisible is
+// that a script, an agent, or a person skimming reads exit 0 as success.
+//
+// Which refusal it is deliberately does not matter here: project permissions
+// and device registration produce the same 403 on the same door, and the CLI
+// must not have to tell them apart to report a failure. So the hub is fronted
+// by a proxy that 403s the journal PUT and nothing else — the exact shape of
+// the report, without pinning the test to one of the two causes.
+func TestSyncFailsWhenTheHubRefusesThePush(t *testing.T) {
+	hub, browser := sec8Hub(t) // also leaves a signed-in settings.json
+
+	target, err := url.Parse(hub.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Off until the project exists and the folder is enrolled: refusing before
+	// then would test setup rather than sync.
+	var refuse atomic.Bool
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	front := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if refuse.Load() && r.Method == http.MethodPut &&
+			strings.HasSuffix(r.URL.Path, "/store/object") &&
+			strings.HasPrefix(r.URL.Query().Get("key"), "journal/") {
+			http.Error(w, "this device is not registered to your account on this hub",
+				http.StatusForbidden)
+			return
+		}
+		proxy.ServeHTTP(w, r)
+	}))
+	t.Cleanup(front.Close)
+
+	// The device's token only travels to the server it was issued for
+	// (remote.deviceToken -> sameOrigin), so the saved server has to be the
+	// front door the project's remote also names.
+	s, err := config.LoadSettings()
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Server = front.URL
+	if err := config.SaveSettings(s); err != nil {
+		t.Fatal(err)
+	}
+
+	var made struct {
+		Project struct {
+			ID string `json:"id"`
+		} `json:"project"`
+	}
+	sec8JSON(t, browser, "POST", hub.URL+"/api/projects", map[string]string{"name": "refused"}, &made, "")
+	if made.Project.ID == "" {
+		t.Fatal("setup: no project created")
+	}
+
+	folder := t.TempDir()
+	if _, err := config.SaveProject(folder, config.Project{
+		Volume: "refused",
+		Remote: front.URL + "/p/" + made.Project.ID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := config.EnrollMount(folder); err != nil {
+		t.Fatal(err)
+	}
+
+	refuse.Store(true)
+	if err := os.WriteFile(filepath.Join(folder, "note.md"), []byte("a day of work"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := seccliRun(t, syncCmd(), []string{folder})
+	if err == nil {
+		t.Fatalf("a refused push exited 0 — the failure reads as success:\n%s", out)
+	}
+	if !strings.Contains(out, "read-only") {
+		t.Errorf("the refusal never appeared in the summary:\n%s", out)
+	}
+	if !strings.Contains(out, "not registered to your account") {
+		t.Errorf("the hub's own reason never reached the user:\n%s", out)
+	}
+
+	// `bdrive url --sync` makes the same promise in miniature — "push right
+	// now, so the link works immediately" — and handing a teammate a link to
+	// content the hub never received is the same silent failure. The link
+	// itself is still the correct URL, so it stays on stdout for whatever
+	// captured it and the warning goes to stderr.
+	t.Chdir(folder)
+	uc := urlCmd()
+	var stderr bytes.Buffer
+	uc.SetErr(&stderr)
+	link, err := seccliRun(t, uc, []string{"note.md", "--sync"})
+	if err != nil {
+		t.Fatalf("url --sync: %v\n%s", err, link)
+	}
+	if !strings.Contains(link, made.Project.ID) {
+		t.Errorf("url --sync stopped printing the link:\n%s", link)
+	}
+	if !strings.Contains(stderr.String(), "will not resolve") {
+		t.Errorf("url --sync promised an immediately-resolving link and said nothing about the refusal:\n%s",
+			stderr.String())
+	}
+}

--- a/cmd/bdrive/url.go
+++ b/cmd/bdrive/url.go
@@ -82,8 +82,23 @@ Computed locally from the folder's config; no network unless --sync.`,
 					return err
 				}
 				defer closeSession(sess)
-				if _, err := sess.Cycle(cmd.Context()); err != nil {
+				res, err := sess.Cycle(cmd.Context())
+				if err != nil {
 					return err
+				}
+				// --sync exists so the link resolves immediately, so a refused
+				// push breaks the one promise the flag makes. The link itself
+				// is still the right URL — it just points at content the hub
+				// does not have — so it goes to stdout as asked and the warning
+				// goes to stderr, where a `bdrive url --sync > link.txt` still
+				// shows it. Same silent-failure class as `bdrive sync` exiting
+				// 0 on a refusal (BEA-183), one file over.
+				if res.ReadOnly || res.NoAccess {
+					fmt.Fprintf(cmd.ErrOrStderr(),
+						"warning: the hub refused this device's changes, so this link will not resolve yet\n")
+					if reason := res.Reason(); reason != "" {
+						fmt.Fprintf(cmd.ErrOrStderr(), "         %s\n", safeField(reason, 300))
+					}
 				}
 			}
 			link := server + "/" + projectID

--- a/internal/webapp/cli_provider_e2e_test.go
+++ b/internal/webapp/cli_provider_e2e_test.go
@@ -133,7 +133,9 @@ func startManagedHub(t *testing.T, callBinder bool) (*httptest.Server, string, s
 
 // cliprovRun signs the CLI in, connects it to the project, and syncs one file.
 // It returns the `bdrive sync` output and the hub's journal directory.
-func cliprovRun(t *testing.T, callBinder bool) (string, string) {
+// Returns the sync's combined output, the hub's journal directory, and the
+// sync's exit status.
+func cliprovRun(t *testing.T, callBinder bool) (string, string, error) {
 	t.Helper()
 	if testing.Short() {
 		t.Skip("builds and execs the bdrive binary; skipped with -short")
@@ -171,18 +173,21 @@ func cliprovRun(t *testing.T, callBinder bool) (string, string) {
 	// The daemon init started keeps cycling; `sync` takes the same volume flock,
 	// so the two serialize rather than race. Not stopped first on purpose —
 	// `bdrive stop` PAUSES the mount, and a paused mount refuses to sync at all.
-	out, err := run(work, "sync", work)
-	if err != nil {
-		t.Fatalf("sync: %v\n%s", err, out)
-	}
-	return out, journalDir
+	// The exit code is returned rather than asserted here: a refused push now
+	// fails the command (BEA-183), so the two callers want opposite answers and
+	// the exit code is part of what each is pinning.
+	out, syncErr := run(work, "sync", work)
+	return out, journalDir, syncErr
 }
 
 // A managed provider that honours the contract: the device binds at mint and
 // the CLI's journal reaches the hub.
 func TestCLIManagedProviderDeviceCanPush(t *testing.T) {
-	out, journalDir := cliprovRun(t, true)
+	out, journalDir, syncErr := cliprovRun(t, true)
 
+	if syncErr != nil {
+		t.Fatalf("sync: %v\n%s", syncErr, out)
+	}
 	if strings.Contains(out, "read-only") {
 		t.Fatalf("a bound device was refused:\n%s", out)
 	}
@@ -203,8 +208,14 @@ func TestCLIManagedProviderDeviceCanPush(t *testing.T) {
 // that ignores the binder produces exactly the reported symptom — a `write`
 // member whose blobs upload and whose journal is refused, forever.
 func TestCLIManagedProviderThatIgnoresTheBinderIsRefused(t *testing.T) {
-	out, journalDir := cliprovRun(t, false)
+	out, journalDir, syncErr := cliprovRun(t, false)
 
+	// Non-zero as well as loud. Printing the refusal and exiting 0 is what let
+	// a day of work sit unpushed and unnoticed (BEA-183): the summary above it
+	// reads `local changes: 0`, so every visible signal said success.
+	if syncErr == nil {
+		t.Fatalf("a refused push exited 0 — the failure reads as success:\n%s", out)
+	}
 	if !strings.Contains(out, "read-only") {
 		t.Fatalf("expected the documented refusal, got:\n%s", out)
 	}

--- a/web/docs/src/content/docs/reference/cli.md
+++ b/web/docs/src/content/docs/reference/cli.md
@@ -20,7 +20,7 @@ One binary, `bdrive` — the CLI, the sync daemon, and the web server.
 | `bdrive grep <pattern> [folder]` | Search the text **inside** the files a project syncs. `pattern` is a Go RE2 regexp, or a literal string with `-F`. `-i` ignores case, `-l` prints matching paths only, `-n` caps the lines printed (default 200, `0` = all). Pure read: no daemon, no lock, no network |
 | `bdrive stale [folder]` | Find synced markdown that links to a file written **after** the doc itself — staleness by what moved, not by the calendar. `-l` prints outgrown paths only, `-n` caps the docs printed (default 50, `0` = all). Pure read: no daemon, no lock, no network. Exit status is 0 whether or not anything is stale |
 | `bdrive forget <path>...` | Stop syncing a path and remove it from the hub. Adds the rule to `.bdriveignore` (which syncs) and prunes in one step. Local files are never touched, here or on teammates' devices |
-| `bdrive url [path]` | Internal hub link for a file or folder — sign-in and membership required. `--sync` pushes first; no argument gives the project home. Computed locally |
+| `bdrive url [path]` | Internal hub link for a file or folder — sign-in and membership required. `--sync` pushes first, and warns on stderr if the hub refused that push; no argument gives the project home. Computed locally |
 | `bdrive share <file>` | Public URL for a synced file — links are per-file, so a folder is refused with a file inside it named instead. `--list`, `--revoke`, `--expires` (the hub's Share dialog can also set an expiry on an existing link). Refuses a file whose first 1 MiB holds credential-shaped strings — `--force` shares it anyway |
 | `bdrive sync [folder]` | Run one sync cycle now. Refuses folders this device never `init`ed and folders paused by `bdrive stop`. `--note <text>` stamps session context onto changes; `--note-ttl` (default 30m) bounds it, and a plain `bdrive sync` with no `--note` clears it. `--prune` also removes from the hub what `.bdriveignore` now excludes (files stay on disk everywhere). `--hook <label>` is agent-hook plumbing: it also reports the files teammates changed since the agent's last turn |
 | `bdrive hooks [install\|uninstall]` | Register turn-boundary sync hooks in each detected agent platform's user config — once per machine, covering every folder. Run automatically by `bdrive init`; idempotent; `--agent` overrides detection. `uninstall` removes only BearDrive's own hook entries |
@@ -323,6 +323,13 @@ cheap local-only ticks between remote passes, which never ask the hub anything
 and so never revise its last answer. For the permission answers, the fix is in
 the hub's Project settings → People; see
 [Project permissions](/concepts/permissions/).
+
+`bdrive sync` **exits non-zero** on either. The blobs really do upload — only
+the journal is refused — so the progress line reads `uploading 11 files` and
+the summary reads `local changes: 0`, which a script, an agent, or a person
+skimming takes for success. It isn't one: nothing reached the hub, and nothing
+will until the refusal is dealt with. Being offline still exits 0, because that
+one retries itself.
 
 ### `bdrive login` and switching hubs
 


### PR DESCRIPTION
## TL;DR

- `bdrive sync` used to exit **0** after the hub refused the push — it printed `uploading 11 files`, then `local changes: 0`, and a day of work sat unpushed and unnoticed. Now it exits non-zero.
- `bdrive url --sync` had the same hole: its whole promise is "the link resolves immediately", and it printed a link to content the hub never got. Now it warns on stderr (the link still goes to stdout).
- **The reported cause is not the bug.** The store PUT route already accepts `perm: write`; what refuses is the *device-registration* gate, whose only escape hatch happens to be project-admin.
- Liam's actual remedy is **upgrade past v0.13.0 and re-run `bdrive login`** — the reason line, the collapsed daemon log, and device binding itself all shipped in v0.15.0.
- Offline still exits 0, and `sync --hook` still never fails: those retry themselves.

## What was actually wrong on the reporter's machine

BEA-183 hypothesised that the push path gates on `admin` and rejects `write`. It doesn't:

```go
mux.HandleFunc("PUT /api/p/{project}/store/object", proj(PermWrite, s.handleStorePut))
```

The only `PermAdmin` anywhere on the push path is the recovery arm in `ownJournal` (`internal/webapp/store.go`), which runs **only for `journal/` keys** and only decides whether this device may write *its own* log:

```go
switch {
case normEmail(owner) == me:                              // my device, my journal
case atLeast(s.projectPerm(r, ...), PermAdmin):           // project admin: the recovery path
default:                                                   // 403
}
```

So an **unbound device** pushes fine to `admin` projects and is refused on every `write` project — one device, one token, one daemon, exactly the reported split between `board` and `team`. Blobs are content-addressed and carry no owner, which is why `uploading 11 files` genuinely succeeded and only the journal 403'd.

The `?key=probe` → `400` evidence doesn't clear this: `storeKey` validates the key *before* `ownJournal` runs, so that probe never reached the check that was refusing.

Ownership comes from `DeviceRegistry.Bind`, called when the hub mints a token — and only if the CLI sent `X-Bdrive-Device` on login (`postAsDevice`, `cmd/bdrive/login.go`). **v0.13.0 sends nothing.** All three of the binding gate (`77a6854`), the `reason:` line and the daemon's collapsed logging (`922886b`) first shipped in **v0.15.0**, which is why the reporter saw a bare `read-only (pull only)` with no explanation and 300+ alternating daemon lines.

| Ticket ask | Status |
|---|---|
| 1. Accept `write` as writable | Not a bug — route is already `PermWrite` |
| 2. **Make the failure loud** | **Fixed here** |
| 3. Stop the flapping | Already fixed in v0.15.0 (`922886b`) |
| 4. Surface the discrepancy | Already fixed in v0.15.0 — prints `this device is not registered to your account on this hub; update bdrive, then run bdrive login` |

## The fix

`syncOne` records targets whose cycle ended `ReadOnly` or `NoAccess`, and the command fails **after every target has run** — the other mounts under a folder may be perfectly healthy and still want syncing. `sync --hook` returns before that loop, so agent hooks still never fail.

Offline deliberately keeps exiting 0: it retries itself. A refusal doesn't — it stays refused until somebody acts, which is what makes exit 0 a lie.

`bdrive url --sync` gets a stderr warning rather than a failure: the URL it prints is still the *correct* URL, so `bdrive url --sync > link.txt` keeps working and the human is told the link isn't live yet.

## Test

`cmd/bdrive/sync_refused_test.go` — in-process (2.6s), fronting the real hub with a proxy that 403s the journal PUT and nothing else. It reproduces the reported output exactly; on the pre-fix tree it fails with:

```
a refused push exited 0 — the failure reads as success:
  uploading 1 files (13 B)
  100%  1/1 files  13 B / 13 B
synced /tmp/.../proj (project "refused")
  local changes:  1
  pulled changes: 0
  files updated:  0
  remote:         read-only (pull only) — local changes stay on this device
                  this device is not registered to your account on this hub
```

The proxy is deliberate: project permissions and device registration produce the same 403 on the same door, and the CLI must not have to tell them apart to report a failure.

## Docs

`README.md` and `web/docs/.../reference/cli.md` — the exit-code contract in the access section, and the `--sync` warning on the `bdrive url` row.

## An existing test asserted the bug

`TestCLIManagedProviderThatIgnoresTheBinderIsRefused` (`internal/webapp/cli_provider_e2e_test.go`) builds exactly the BEA-183 device — unbound id, `write` project, blobs up and journal refused — and its helper treated any non-zero `bdrive sync` as a broken fixture:

```go
out, err := run(work, "sync", work)
if err != nil {
    t.Fatalf("sync: %v\n%s", err, out)   // <- the fixture aborts here now
}
```

So it asserted the refusal was *printed* while asserting, by omission, that the command still exited **0**. That is the defect it was meant to guard. `cliprovRun` now returns the exit status and each caller pins the one it expects: nil for the bound device, non-nil for the refused one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

