### PR TITLE
fix(webapp): a mermaid diagram using [[label]] renders instead of breaking (BEA-184)

### DIFF
--- a/internal/webapp/markdown.go
+++ b/internal/webapp/markdown.go
@@ -9,30 +9,74 @@ import (
 	"strings"
 
 	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
 	"gopkg.in/yaml.v3"
 )
 
 var md = goldmark.New(
 	goldmark.WithExtensions(extension.GFM),
-	goldmark.WithParserOptions(parser.WithAutoHeadingID()),
+	goldmark.WithParserOptions(
+		parser.WithAutoHeadingID(),
+		// 150 is load-bearing: below goldmark's link parser (200) so `[[`
+		// is claimed before the ordinary link syntax sees the first `[`,
+		// above its code span parser (100) so backticks still swallow
+		// their contents whole.
+		parser.WithInlineParsers(util.Prioritized(wikiParser{}, 150)),
+	),
 )
 
-// wikiRe matches Obsidian-style [[target]] and [[target|label]] links.
-var wikiRe = regexp.MustCompile(`\[\[([^\]|]+)(?:\|([^\]]+))?\]\]`)
+// wikiParser expands Obsidian-style [[target]] and [[target|label]] to
+// <a href="wiki:target">, which the frontend resolves against the file tree
+// by basename (FileView.tsx).
+//
+// It is an inline parser rather than a rewrite of the raw source so that code
+// never sees it. goldmark runs no inline parser over a fenced or indented code
+// block, and a code span outranks this one, so `[[x]]` inside backticks or a
+// ``` block survives verbatim — which is the whole point: Mermaid's subroutine
+// node shape is written B[[label]], and rewriting it handed Mermaid a diagram
+// that could not parse.
+//
+// Two consequences of parsing instead of rewriting, both matching Obsidian:
+// a label is literal text ([[t|*v*]] renders *v*, not <em>v</em>), and a
+// wikilink cannot span a newline.
+type wikiParser struct{}
 
-// expandWikilinks rewrites [[target]] to a markdown link with a wiki: URL;
-// the frontend resolves the target against the file tree by basename.
-func expandWikilinks(src []byte) []byte {
-	return wikiRe.ReplaceAllFunc(src, func(m []byte) []byte {
-		g := wikiRe.FindSubmatch(m)
-		target, label := g[1], g[2]
-		if len(label) == 0 {
-			label = target
-		}
-		return []byte("[" + string(label) + "](wiki:" + url.PathEscape(string(target)) + ")")
-	})
+func (wikiParser) Trigger() []byte { return []byte{'['} }
+
+// Parse matches [[target]] / [[target|label]] on the current line. Neither
+// half may contain `]` — the first `]` must be the closer — which is what
+// keeps a destination-breaking target like [[a) [pwn](javascript:...)]]
+// literal text, exactly as the regex this replaced left it.
+func (wikiParser) Parse(parent ast.Node, block text.Reader, pc parser.Context) ast.Node {
+	line, seg := block.PeekLine()
+	if len(line) < 5 || line[1] != '[' { // [[x]] is the shortest form
+		return nil
+	}
+	body := line[2:]
+	i := bytes.IndexByte(body, ']')
+	if i < 1 || i+1 >= len(body) || body[i+1] != ']' {
+		return nil
+	}
+	target, label := body[:i], body[:i]
+	if j := bytes.IndexByte(target, '|'); j >= 0 {
+		target, label = target[:j], target[j+1:]
+	}
+	if len(target) == 0 || len(label) == 0 {
+		return nil
+	}
+	// The label is a segment into the source, not a new string, so goldmark's
+	// own text renderer escapes it the way it escapes every other text node.
+	// It is a suffix of body[:i], so its offset falls out of the lengths.
+	labelStart := seg.Start + 2 + i - len(label)
+	block.Advance(i + 4) // "[[" + body[:i] + "]]"
+	link := ast.NewLink()
+	link.Destination = []byte("wiki:" + url.PathEscape(string(target)))
+	link.AppendChild(link, ast.NewTextSegment(text.NewSegment(labelStart, labelStart+len(label))))
+	return link
 }
 
 // RenderMarkdown converts markdown to HTML (GFM + wikilinks). Raw HTML in
@@ -68,7 +112,7 @@ func RenderMarkdownPairs(src []byte) ([]FrontmatterPair, string, error) {
 
 func renderBody(body []byte) (string, error) {
 	var buf bytes.Buffer
-	if err := md.Convert(expandWikilinks(body), &buf); err != nil {
+	if err := md.Convert(body, &buf); err != nil {
 		return "", err
 	}
 	return buf.String(), nil

--- a/internal/webapp/server_test.go
+++ b/internal/webapp/server_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"html"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -309,10 +310,44 @@ func TestConfigBrandNeverLeaksVolume(t *testing.T) {
 	}
 }
 
-func TestExpandWikilinks(t *testing.T) {
-	got := string(expandWikilinks([]byte("a [[x y]] b [[u|v]] c [[no")))
-	want := "a [x y](wiki:x%20y) b [v](wiki:u) c [[no"
-	if got != want {
-		t.Errorf("got %q, want %q", got, want)
+// TestWikilinkRendering drives the real renderer over one document holding
+// every context a [[…]] can sit in. Prose must keep emitting exactly the
+// anchor FileView.tsx resolves; code must come out byte-identical, which is
+// the bug — a mermaid subroutine node B[[label]] used to reach mermaid as
+// B[label](wiki:label) and refuse to parse.
+func TestWikilinkRendering(t *testing.T) {
+	const mermaid = "flowchart LR\n  A[input] --> B[[stored record]]"
+	src := "a [[x y]] b [[u|v]] c [[no\n\n" +
+		"span `[[target]]` end\n\n" +
+		"```mermaid\n" + mermaid + "\n```\n"
+
+	got, err := RenderMarkdown([]byte(src))
+	if err != nil {
+		t.Fatalf("RenderMarkdown: %v", err)
+	}
+
+	// Prose: unchanged from the regex this replaced.
+	for _, want := range []string{
+		`<a href="wiki:x%20y">x y</a>`,
+		`<a href="wiki:u">v</a>`,
+		`c [[no`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("prose: %q missing from\n%s", want, got)
+		}
+	}
+
+	// Code span: literal, no rewrite and no anchor.
+	if !strings.Contains(got, "<code>[[target]]</code>") {
+		t.Errorf("code span was rewritten:\n%s", got)
+	}
+
+	// Fenced block: the bytes mermaid receives are the bytes on disk.
+	inner := html.EscapeString(mermaid)
+	if !strings.Contains(got, inner) {
+		t.Errorf("fenced block not byte-identical, want %q in\n%s", inner, got)
+	}
+	if strings.Contains(got, "wiki:stored") {
+		t.Errorf("fenced block was rewritten:\n%s", got)
 	}
 }


### PR DESCRIPTION
## TL;DR

- A Mermaid diagram that uses the subroutine node shape `B[[label]]` now renders instead of erroring — the viewer was corrupting the diagram source before Mermaid ever saw it.
- Writing *about* `[[wikilinks]]` in backticks stops being rewritten too: `` `[[target]]` `` used to render as `[target](wiki:target)`.
- One change fixes both surfaces — the hub viewer and every public `/s/` share page share `renderBody`.
- Prose wikilinks are byte-identical, and the three existing escaping tests pass unmodified.
- Known gaps (deliberate, both match Obsidian): a pipe alias is now literal text (`[[t|*v*]]` renders `*v*`, not `<em>v</em>`), and a wikilink can no longer span a newline.

## What was wrong

`expandWikilinks` ran a regex over the **whole raw document** before goldmark parsed anything. A regex has no notion of markdown structure, so it fired in the two places it must not — and in exactly those places it produced no anchor. It corrupted the source and gave nothing back.

```mermaid
flowchart LR
  SRC["raw document body"] --> RX["expandWikilinks<br/>regex, markdown.go:27"]
  RX --> P["prose"]
  RX --> C["fenced block / code span"]
  P --> POK["a href=wiki:x<br/>correct"]
  C --> CBAD["source rewritten<br/>NO anchor<br/>Mermaid refuses to parse"]
  style CBAD fill:#7f1d1d,color:#fff
  style POK fill:#14532d,color:#fff
```

Mermaid's subroutine node is written with exactly the matched syntax, so a diagram on disk reading

```
flowchart LR
  A[input] --> B[[stored record]]
```

reached Mermaid as `A[input] --> B[stored record](wiki:stored%20record)`. The error on screen named Mermaid, which is not where the problem was — the file on disk and the string Mermaid received were different, and nothing said so.

Both renderers were affected because both call `renderBody`: `RenderMarkdown` (public share pages) and `RenderMarkdownPairs` (the viewer).

## The fix

Expansion becomes a goldmark **inline parser** registered on the `[` trigger at **priority 150**. The priority is load-bearing and is the whole mechanism:

| parser | priority | effect |
| -- | -- | -- |
| code span | 100 | wins inside backticks — a code span still swallows its contents whole |
| **wikilink** | **150** | claims `[[` before ordinary link syntax sees the first `[` |
| link | 200 | unchanged |

Fenced and indented code are block-level raw text that goldmark runs **no** inline parser over, so that half needs no code at all. Both reported contexts stop being rewritten because of *where they sit*, not because of a new exclusion list somebody has to maintain.

`Parse` reads one line, requires `[[`, takes the first `]` as the closer and requires the next byte to be `]` too, splits target/label on the first `|`, and builds the `ast.Link` directly.

## Escaping — the actual risk

The old code was safe by construction: it percent-escaped the target and re-emitted markdown that goldmark then parsed and escaped for it. An inline parser builds the node itself, so escaping becomes this code's responsibility. Two things keep it safe:

- the destination still goes through `url.PathEscape`, and goldmark's renderer calls `util.URLEscape(dest, true)`, which **preserves** existing `%XX` rather than double-escaping — so the emitted `href` is byte-identical;
- the label is appended as a source **segment** (`ast.NewTextSegment`), not a Go string, so goldmark's own `renderText` escapes it through the same path every other text node takes.

The three existing escaping tests pass **unmodified** and were the acceptance gate:

- `TestSec_Render_PeerMarkdownNeverBecomesMarkupOrScript` (`sec_restore_test.go:325`) — PASS
- `TestSec_Render_MarkdownCannotShipActiveContent`, subtests `wikilink with quote break` and `wikilink label injection` (`sec_defer_test.go:1032-1033`) — PASS

`[[a) [pwn](javascript:alert(1)]]` stays literal text for the same reason it always did: neither half may contain `]`, so the first `]` must be the closer. That was left alone deliberately — a parser that accepted it would be a new escaping surface those tests were written against.

## Old vs new, every shape

Diffed by rendering each input through both implementations side by side.

| input | old | new |
| -- | -- | -- |
| `a [[x y]] b [[u\|v]] c [[no` | `<a href="wiki:x%20y">x y</a> … <a href="wiki:u">v</a> … c [[no` | **identical** |
| inline code span holding `[[target]]` | `<code>[target](wiki:target)</code>` | `<code>[[target]]</code>` ✅ |
| fenced mermaid with `B[[stored record]]` | corrupted, parse error | source byte-identical ✅ |
| indented code block | rewritten | untouched ✅ |
| `[[a) [pwn](javascript:alert(1)]]` | literal | **identical** |
| `[[t\|<img src=x onerror=alert(1)>]]` | `<a href="wiki:t"><!-- raw HTML omitted --></a>` | `<a href="wiki:t">&lt;img …&gt;</a>` — still inert, now visible |
| `[[a") onmouseover="alert(1)]]` | `<a href="wiki:a%22%29%20onmouseover=%22alert%281%29">…` | **identical** |
| `[[t\|v\|w]]`, `[[\|v]]`, `[[t\|]]`, unicode, tables, emphasis, adjacent | — | **identical** |
| `[[t\|*v*]]` | `<em>v</em>` | `*v*` ← changed, see gaps |
| `[[foo]]` split across a newline | `<a href="wiki:foo%0Abar">` | literal ← changed, see gaps |
| `# [[x y]]` | heading id `x-ywikix20y` | heading id `x-y` ← incidental fix; auto ids no longer see rewritten markdown |
| `\[[x]]` | leaked `[x](wiki:x)` as text | literal `[[x]]` |
| `[[a[b]]` | `[a<a href="wiki:a%5Bb">b</a>` — label mangled | `<a href="wiki:a%5Bb">a[b</a>` |

## Screenshots

Same file, same committed frontend, hub built from `origin/main` vs this branch.

| before (`origin/main`) | after (this branch) |
| -- | -- |
| ![before](https://raw.githubusercontent.com/runbear-io/beardrive/pr-assets/bea-184/shots/viewer-before.png) | ![after](https://raw.githubusercontent.com/runbear-io/beardrive/pr-assets/bea-184/shots/viewer-after.png) |

## Known gaps

Both are deliberate, both match Obsidian, and both fall out of parsing instead of rewriting:

- **A pipe alias no longer renders inline markup.** `[[t|*v*]]` was `<em>v</em>` and is now literal `*v*`. In Obsidian an alias is literal text, and this is what makes label escaping the parser's own business rather than goldmark's.
- **A wikilink cannot span a newline.** The old `[^\]|]+` matched `\n`, so a `[[…]]` broken across two lines produced a link with `%0A` in its target. Inline parsers see one line at a time. Obsidian does not support this either.

## Tests

- `TestExpandWikilinks` (`server_test.go:312`) called a function that no longer exists, so it is **replaced** by `TestWikilinkRendering` — one document driving `RenderMarkdown` (the share-page renderer) over prose, `[[t|v]]`, an unterminated `[[no`, an inline code span and a fenced `mermaid` block, asserting the fenced block's inner text is byte-identical to the input. That last assertion is the bug. **PASS.**
- The two escaping gates listed above: **PASS**, unmodified.
- `go vet ./...` — clean.
- `go test ./...` — every package green except `internal/webapp`: `cmd/bdrive`, `agenthooks`, `autostart`, `config`, `daemon`, `journal`, `remote`, `secrets`, `store`, `syncer`, `templates`.
- `internal/webapp` takes ~3h here, so it was run in shards. All 574 non-CLI tests pass. See below for the rest.
- `npm run e2e` — **201 passed**. Two specs timed out on the first pass and both pass on re-run (`sec11fe` 12/12, `sec13fe` 9/9).
- No frontend change, so no `npm run build`; `internal/webapp/static` is untouched.

### Failures that are not this branch

This machine sat at load average 60–146 throughout (other work, not the suite). Two failure modes showed up, both verified against `origin/main`:

| failure | evidence it is not this branch |
| -- | -- |
| `TestAuthRateLimit` (`gating_test.go:264`) | fails **identically on `origin/main`** when run in isolation, in both worktrees |
| 8 CLI/delta e2e tests, all failing at `waitForApprovalLink` — *"login --device never printed an approval link"* | `TestCLIOnboardingE2E` and `TestCLIConnectAdoptsProjectVersions` fail **identically on `origin/main`** under the same load. The helper gives a freshly built 79 MB binary **15 seconds** to print its first line, and `go build` of `cmd/bdrive` alone takes ~4 min here. `TestCLISecretsWarnOnSync` failed the same way and then passed **3/3** on re-run |

That helper runs before any markdown is rendered, in a device-login path this change cannot reach. Worth knowing: the 15s budget in `waitForApprovalLink` is tight enough to be a recurring CI nuisance, but tightening it is not this PR's business.

## Architecture

No diagram update. `architecture/webapp-server.md` draws `markdownRender` with `frontmatterPairs` / `RenderMarkdown` / `RenderMarkdownPairs` / `yamlValue`; `expandWikilinks` was never on it, and a private parser struct inside `markdown.go` is below that altitude. No type, seam or relationship it draws changed.

## Deviation from the plan

None. The plan was built against a prototype on goldmark v1.8.2 and matched the real tree exactly.

## Build session

```
cd $(git worktree list | grep bea-184 | awk '{print $1}') && claude --resume 7c6a5563-72eb-4290-be7a-f8d1d9918474
```

(only works on this machine)
