### PR TITLE
feat(webapp): a pasted hub link unfurls with a real title (BEA-181)

### DIFF
--- a/architecture/webapp-server.md
+++ b/architecture/webapp-server.md
@@ -332,9 +332,20 @@ classDiagram
         &lt;&lt;shares.go, the .md branch&gt;&gt;
         body contains language-mermaid?
         → module script tag, else ""
-        sharedMarkdownShell verb 2 of 4
+        sharedMarkdownShell verb 3 of 5
     }
     note for mermaidTag "A share page is a zero-JavaScript document and stays one unless the document it renders actually has a diagram — the server already holds the rendered HTML, so it can decide. The tag is a MODULE, which only loads because frontend() now sets Access-Control-Allow-Origin on real assets: under this page's `sandbox allow-scripts` the origin is opaque, so a module and every import() it makes are fetched with Origin: null. The CSP itself is unchanged, and no allow-same-origin was added — the sandbox is what keeps shared content off the hub's origin"
+
+    class openGraph {
+        &lt;&lt;og.go&gt;&gt;
+        ogMeta(title, desc, image, type, url) → meta block
+        titleTag(s) → &lt;title&gt;
+        Server.shellTitle(upath) → a name, or empty for today
+        shareDescription(pairs, body) → fm or 1st para, ≤200
+        shareImage(body) → 1st absolute http(s) img
+        sharedMarkdownShell verb 2 of 5
+    }
+    note for openGraph "Unfurlers run no JavaScript, so both injections are server-side; frontend/ and static/ are untouched, which is why go build still needs no Node. The asymmetry is the point: the SPA shell is served with NO session to anyone holding a URL, so it gets name-derived tags only (basename + project name, no storage access — shellTitle reads the URL and one registry entry, behind a projectIDRe guard so a non-project URL never reaches the mutex). Content-derived tags (description, image) live on the markdown share page alone, where the bytes are already public. og:image insists on an absolute http(s) src because RenderMarkdown does no src rewriting, so a relative one is already broken on the live page. .html and binary shares are byte-identical to before — the hub still never injects into raw HTML. An unresolvable project id falls back to the untouched shell, so the tag is not an existence oracle"
 
     class DeviceRegistry {
         -repo DeviceRepo
@@ -501,6 +512,10 @@ classDiagram
     projectPerm ..> Directory : org role
     ShareDB ..> Share
     ShareDB ..> mermaidTag : markdown shares only
+    ShareDB ..> openGraph : ogMeta + shareDescription/shareImage (.md branch)
+    Server ..> openGraph : shellTitle + titleTag, templated into the SPA shell
+    openGraph ..> ProjectDB : Get(id) for the project name
+    openGraph ..> FrontmatterPair : description key
     ShareDB ..> markdownRender : RenderMarkdown (table stays)
     Server ..> markdownRender : RenderMarkdownPairs (viewer)
     markdownRender ..> FrontmatterPair

--- a/internal/webapp/og.go
+++ b/internal/webapp/og.go
@@ -1,0 +1,150 @@
+package webapp
+
+import (
+	"html"
+	"net/url"
+	"path"
+	"regexp"
+	"strings"
+)
+
+// Open Graph tags: what a hub link looks like when it is pasted somewhere
+// that unfurls it (Slack, Discord, iMessage, LinkedIn). Unfurlers do not run
+// JavaScript, so everything here is emitted server-side — the SPA shell is
+// templated in server.go's frontend(), the markdown share page in shares.go.
+//
+// The split of what each surface may say is deliberate: the shell is served
+// UNAUTHENTICATED to anyone holding a URL, so it gets name-derived tags only
+// (a basename and a project name). Content-derived tags (description, image)
+// appear on share pages alone, where the content is already public by
+// construction.
+
+// ogMeta builds the meta block for one page. Values are escaped for an
+// attribute; description and image are emitted only when they have something
+// to say — an empty og:image renders as a broken card, so its absence is the
+// correct output rather than an empty tag.
+func ogMeta(title, desc, image, ogType, pageURL string) string {
+	var b strings.Builder
+	tag := func(prop, val string) {
+		if val == "" {
+			return
+		}
+		b.WriteString(`<meta property="` + prop + `" content="` + html.EscapeString(val) + `">`)
+	}
+	tag("og:title", title)
+	tag("og:site_name", "BearDrive")
+	tag("og:type", ogType)
+	tag("og:url", pageURL)
+	tag("og:description", desc)
+	// Only an absolute http(s) URL is fetchable by an unfurler. A relative
+	// src in a shared document is already broken on the live share page
+	// (RenderMarkdown does no rewriting), so advertising it would only ever
+	// produce a card with a missing image.
+	if u, err := url.Parse(image); err == nil && u.Host != "" &&
+		(u.Scheme == "http" || u.Scheme == "https") {
+		tag("og:image", image)
+	}
+	return b.String()
+}
+
+// titleTag is the <title> element, escaped — kept here so server.go needs no
+// new import to template the shell.
+func titleTag(s string) string {
+	return "<title>" + html.EscapeString(s) + "</title>"
+}
+
+// shellViews mirrors VIEW_ROUTES in frontend/src/router.ts (plus the legacy
+// "insights" alias from LEGACY_VIEWS). A view added there and not here is
+// cosmetic — the URL still names itself, just uncapitalized.
+var shellViews = map[string]string{
+	"dashboard": "Dashboard",
+	"history":   "History",
+	"install":   "Install",
+	"settings":  "Settings",
+	"insights":  "Dashboard", // renamed; see LEGACY_VIEWS
+}
+
+// shellTitle names one SPA URL, or returns "" meaning "serve the shell
+// exactly as it has always been". Costs no storage access: the basename comes
+// from the URL and the project name from an in-memory registry read, so this
+// stays cheap on the hub's hottest handler. Reserved prefixes (join/, orgs/,
+// billing/) and anything whose first segment isn't shaped like a project id
+// never reach the registry at all.
+func (s *Server) shellTitle(upath string) string {
+	if upath == "" || upath == "index.html" {
+		return ""
+	}
+	if s.Root == nil { // volume mode: the whole path is a file, no project name
+		return path.Base(upath)
+	}
+	id, rest, _ := strings.Cut(upath, "/")
+	if !projectIDRe.MatchString(id) {
+		return "" // join/<token>, orgs/…, billing/…, or a typo
+	}
+	p, ok := s.Projects.Get(id)
+	if !ok {
+		// Unresolvable id: the generic shell, with no hint either way about
+		// whether the project exists.
+		return ""
+	}
+	switch {
+	case rest == "":
+		return p.Name
+	case !strings.Contains(rest, "/"):
+		if view, ok := shellViews[rest]; ok {
+			return view + " — " + p.Name
+		}
+	}
+	return path.Base(rest) + " — " + p.Name
+}
+
+var (
+	ogTagRe   = regexp.MustCompile(`<[^>]*>`)
+	ogParaRe  = regexp.MustCompile(`(?s)<p>(.*?)</p>`)
+	ogImageRe = regexp.MustCompile(`<img[^>]*\ssrc="(https?://[^"]*)"`)
+)
+
+// shareDescription is what a share card says under its title: the
+// frontmatter's own description when the author wrote one, otherwise the
+// document's opening prose. Headings, code and images are skipped — only a
+// <p> counts — so a document that starts with a title still describes itself.
+func shareDescription(pairs []FrontmatterPair, body string) string {
+	for _, p := range pairs {
+		if strings.EqualFold(p.Key, "description") {
+			if v := strings.TrimSpace(p.Value); v != "" {
+				return truncateWords(v, 200)
+			}
+		}
+	}
+	m := ogParaRe.FindStringSubmatch(body)
+	if m == nil {
+		return ""
+	}
+	text := html.UnescapeString(ogTagRe.ReplaceAllString(m[1], ""))
+	return truncateWords(strings.Join(strings.Fields(text), " "), 200)
+}
+
+// shareImage is the first image an unfurler could actually fetch. goldmark
+// runs without WithUnsafe, so a raw <img> in the source never survives to be
+// matched here — every hit came from markdown image syntax.
+func shareImage(body string) string {
+	m := ogImageRe.FindStringSubmatch(body)
+	if m == nil {
+		return ""
+	}
+	return html.UnescapeString(m[1])
+}
+
+// truncateWords cuts to at most max runes, on a word boundary, with an
+// ellipsis standing in for what was dropped.
+func truncateWords(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	cut := string(r[:max-1])
+	if i := strings.LastIndexAny(cut, " \t\n"); i > 0 {
+		cut = cut[:i]
+	}
+	return strings.TrimRight(cut, " \t\n") + "…"
+}

--- a/internal/webapp/og_test.go
+++ b/internal/webapp/og_test.go
@@ -1,0 +1,395 @@
+package webapp
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestOGMetaOmitsEmptyAndEscapes(t *testing.T) {
+	tests := []struct {
+		name               string
+		title, desc, image string
+		ogType, url        string
+		want, absent       []string
+	}{
+		{
+			name: "minimal", title: "spec.md", ogType: "website", url: "https://h/x",
+			want: []string{
+				`<meta property="og:title" content="spec.md">`,
+				`<meta property="og:site_name" content="BearDrive">`,
+				`<meta property="og:type" content="website">`,
+				`<meta property="og:url" content="https://h/x">`,
+			},
+			// An empty description or image renders a broken card: no tag at
+			// all is the correct output, not an empty one.
+			absent: []string{"og:description", "og:image"},
+		},
+		{
+			name: "full", title: "a", desc: "hello", image: "https://cdn.example/i.png",
+			ogType: "article", url: "https://h/s/tok",
+			want: []string{
+				`<meta property="og:description" content="hello">`,
+				`<meta property="og:image" content="https://cdn.example/i.png">`,
+			},
+		},
+		{
+			name: "relative image dropped", title: "a", image: "diagram.png",
+			ogType: "article", url: "https://h/s/tok", absent: []string{"og:image"},
+		},
+		{
+			name: "scheme-relative image dropped", title: "a", image: "//cdn/x.png",
+			ogType: "article", url: "https://h/s/tok", absent: []string{"og:image"},
+		},
+		{
+			name: "javascript image dropped", title: "a", image: "javascript:alert(1)",
+			ogType: "article", url: "https://h/s/tok", absent: []string{"og:image"},
+		},
+		{
+			name:   `hostile`,
+			title:  `"><script>alert(1)</script>`,
+			desc:   `he said "hi" & <b>left</b>`,
+			ogType: "website", url: "https://h/x",
+			want: []string{`&#34;&gt;&lt;script&gt;`, `&amp;`, `&lt;b&gt;`},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ogMeta(tc.title, tc.desc, tc.image, tc.ogType, tc.url)
+			for _, w := range tc.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("missing %q in %s", w, got)
+				}
+			}
+			for _, a := range tc.absent {
+				if strings.Contains(got, a) {
+					t.Errorf("unexpected %q in %s", a, got)
+				}
+			}
+			// Nothing hostile survives into attribute position. Checked per
+			// tag: an unescaped ">" or quote in a value would truncate its
+			// own tag, so a well-formed line is itself the assertion.
+			for _, meta := range ogLines(got) {
+				if !strings.HasSuffix(meta, `">`) {
+					t.Errorf("malformed tag %q", meta)
+				}
+				for _, bad := range []string{"<script", "<b>", `content="">`} {
+					if strings.Contains(meta, bad) {
+						t.Errorf("unescaped %q in %s", bad, meta)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestShellTitleNamesEveryRouteShape(t *testing.T) {
+	srv, p, _ := newHub(t, true, nil)
+	for _, tc := range []struct{ upath, want string }{
+		{"", ""},
+		{"index.html", ""},
+		{"join/abc123", ""},
+		{"orgs/o1", ""},
+		{"billing", ""},
+		{"not-a-project-id/notes.md", ""},
+		{"3f2b1c4d-0000-0000-0000-000000000000/notes.md", ""}, // well-shaped, unknown
+		{p.ID, "proj"},
+		{p.ID + "/dashboard", "Dashboard — proj"},
+		{p.ID + "/history", "History — proj"},
+		{p.ID + "/install", "Install — proj"},
+		{p.ID + "/settings", "Settings — proj"},
+		{p.ID + "/insights", "Dashboard — proj"}, // legacy alias
+		{p.ID + "/notes/spec.md", "spec.md — proj"},
+		{p.ID + "/notes", "notes — proj"},
+		{p.ID + "/a/b/c/deep.md", "deep.md — proj"},
+	} {
+		if got := srv.shellTitle(tc.upath); got != tc.want {
+			t.Errorf("shellTitle(%q) = %q, want %q", tc.upath, got, tc.want)
+		}
+	}
+
+	// Volume mode has no project to name: the basename alone.
+	vol := &Server{}
+	for _, tc := range []struct{ upath, want string }{
+		{"", ""},
+		{"notes/spec.md", "spec.md"},
+	} {
+		if got := vol.shellTitle(tc.upath); got != tc.want {
+			t.Errorf("volume shellTitle(%q) = %q, want %q", tc.upath, got, tc.want)
+		}
+	}
+}
+
+func TestShellOpenGraph(t *testing.T) {
+	srv, p, _ := newHub(t, true, nil)
+	h := srv.Handler()
+
+	generic := do(t, h, "GET", "/", nil).Body.String()
+	if !strings.Contains(generic, "<title>BearDrive</title>") {
+		t.Fatal("root shell lost its generic title")
+	}
+
+	// Anonymous: no session anywhere in this test.
+	rec := do(t, h, "GET", "/"+p.ID+"/notes/spec.md", nil)
+	body := rec.Body.String()
+	for _, want := range []string{
+		"<title>spec.md — proj</title>",
+		`<meta property="og:title" content="spec.md — proj">`,
+		`<meta property="og:site_name" content="BearDrive">`,
+		`<meta property="og:type" content="website">`,
+		`<meta property="og:url" content="http://example.com/` + p.ID + `/notes/spec.md">`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("file route missing %q", want)
+		}
+	}
+	// The shell is unauthenticated, so nothing derived from file CONTENT
+	// may appear on it.
+	for _, bad := range []string{"og:description", "og:image", "<title>BearDrive</title>"} {
+		if strings.Contains(body, bad) {
+			t.Errorf("file route should not contain %q", bad)
+		}
+	}
+	// Everything except the head is untouched.
+	if strings.Count(body, "<script type=\"module\"") != strings.Count(generic, "<script type=\"module\"") {
+		t.Error("shell body changed beyond the head")
+	}
+	for _, hdr := range [][2]string{
+		{"Cache-Control", "no-cache"},
+		{"X-Frame-Options", "DENY"},
+		{"X-Content-Type-Options", "nosniff"},
+		{"Content-Security-Policy", "frame-ancestors 'none'"},
+	} {
+		if got := rec.Header().Get(hdr[0]); got != hdr[1] {
+			t.Errorf("%s = %q, want %q", hdr[0], got, hdr[1])
+		}
+	}
+
+	if b := do(t, h, "GET", "/"+p.ID+"/dashboard", nil).Body.String(); !strings.Contains(b,
+		`<meta property="og:title" content="Dashboard — proj">`) {
+		t.Error("view route not named")
+	}
+
+	// Generic routes stay byte-identical to the root shell — including an id
+	// that is shaped like a project but does not exist, which must not become
+	// an existence oracle.
+	for _, u := range []string{"/join/abc", "/3f2b1c4d-0000-0000-0000-000000000000/x.md"} {
+		if b := do(t, h, "GET", u, nil).Body.String(); b != generic {
+			t.Errorf("%s should serve the untouched shell", u)
+		}
+	}
+
+	// assets/* never reaches the template and keeps its immutable caching.
+	arec := do(t, h, "GET", "/assets/", nil)
+	if strings.Contains(arec.Body.String(), "og:") {
+		t.Error("assets response was templated")
+	}
+}
+
+func TestShareDescriptionAndImage(t *testing.T) {
+	render := func(t *testing.T, src string) ([]FrontmatterPair, string) {
+		t.Helper()
+		pairs, _ := frontmatterPairs([]byte(src))
+		body, err := RenderMarkdown([]byte(src))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return pairs, body
+	}
+
+	long := strings.Repeat("alpha beta ", 60) // ~660 chars of prose
+	for _, tc := range []struct {
+		name, src, wantDesc, wantImage string
+	}{
+		{
+			name:     "frontmatter wins",
+			src:      "---\ntitle: T\ndescription: from frontmatter\n---\n\nopening paragraph\n",
+			wantDesc: "from frontmatter",
+		},
+		{
+			name:     "case-insensitive key",
+			src:      "---\nDescription: cased\n---\n\nbody\n",
+			wantDesc: "cased",
+		},
+		{
+			name:     "falls back to first paragraph",
+			src:      "# Heading\n\nfirst **prose** here\n\nsecond\n",
+			wantDesc: "first prose here",
+		},
+		{
+			name:     "entities unescaped, whitespace collapsed",
+			src:      "a &amp; b\nwrapped   line\n",
+			wantDesc: "a & b wrapped line",
+		},
+		{
+			name: "no prose at all",
+			src:  "# Only a heading\n",
+		},
+		{
+			name:      "absolute image",
+			src:       "text\n\n![d](https://cdn.example/d.png)\n",
+			wantDesc:  "text",
+			wantImage: "https://cdn.example/d.png",
+		},
+		{
+			name:     "relative image ignored",
+			src:      "text\n\n![d](diagram.png)\n",
+			wantDesc: "text",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pairs, body := render(t, tc.src)
+			if got := shareDescription(pairs, body); got != tc.wantDesc {
+				t.Errorf("description = %q, want %q", got, tc.wantDesc)
+			}
+			if got := shareImage(body); got != tc.wantImage {
+				t.Errorf("image = %q, want %q", got, tc.wantImage)
+			}
+		})
+	}
+
+	t.Run("truncates on a word boundary", func(t *testing.T) {
+		pairs, body := render(t, long)
+		got := shareDescription(pairs, body)
+		if n := len([]rune(got)); n > 200 {
+			t.Fatalf("len = %d, want <= 200", n)
+		}
+		if !strings.HasSuffix(got, "…") || strings.Contains(got, "alph…") {
+			t.Fatalf("not cut on a word boundary: %q", got)
+		}
+	})
+}
+
+func TestShareOpenGraph(t *testing.T) {
+	srv, p, _, f, h := shareHub(t)
+	f.put("dev1", "wiki/card.md", "---\ndescription: the card blurb\n---\n\n# Card\n\n![d](https://cdn.example/d.png)\n")
+	f.put("dev1", "wiki/logo.png", "\x89PNG\r\n\x1a\nbinary")
+
+	mdTok, _ := authedShare(t, srv, h, p.ID, "wiki/card.md")
+	rec := doHTTP(h, httptest.NewRequest("GET", "/s/"+mdTok, nil))
+	if rec.Code != 200 {
+		t.Fatalf("md share: %d %s", rec.Code, rec.Body)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		"<title>card.md</title>",
+		`<meta property="og:title" content="card.md">`,
+		`<meta property="og:site_name" content="BearDrive">`,
+		`<meta property="og:type" content="article">`,
+		`<meta property="og:url" content="http://example.com/s/` + mdTok + `">`,
+		`<meta property="og:description" content="the card blurb">`,
+		`<meta property="og:image" content="https://cdn.example/d.png">`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("md share missing %q", want)
+		}
+	}
+	for _, hdr := range [][2]string{
+		{"Content-Security-Policy", "sandbox allow-scripts allow-popups"},
+		{"X-Content-Type-Options", "nosniff"},
+		{"Referrer-Policy", "no-referrer"},
+	} {
+		if got := rec.Header().Get(hdr[0]); got != hdr[1] {
+			t.Errorf("%s = %q, want %q", hdr[0], got, hdr[1])
+		}
+	}
+
+	// A markdown share with neither blurb nor image emits neither tag.
+	f.put("dev1", "wiki/bare.md", "# Just a heading\n")
+	bareTok, _ := authedShare(t, srv, h, p.ID, "wiki/bare.md")
+	bare := doHTTP(h, httptest.NewRequest("GET", "/s/"+bareTok, nil)).Body.String()
+	for _, bad := range []string{"og:description", "og:image"} {
+		if strings.Contains(bare, bad) {
+			t.Errorf("bare share should not carry %q", bad)
+		}
+	}
+
+	// The hub never injects into raw HTML or binary bodies: those responses
+	// are the stored bytes, unchanged.
+	for _, tc := range []struct{ path, want string }{
+		{"wiki/report.html", "<h1>Q3</h1><script>alert(1)</script>"},
+		{"wiki/logo.png", "\x89PNG\r\n\x1a\nbinary"},
+	} {
+		tok, _ := authedShare(t, srv, h, p.ID, tc.path)
+		got := doHTTP(h, httptest.NewRequest("GET", "/s/"+tok, nil)).Body.String()
+		if got != tc.want {
+			t.Errorf("%s body = %q, want the source bytes", tc.path, got)
+		}
+		if strings.Contains(got, "og:") {
+			t.Errorf("%s was templated", tc.path)
+		}
+	}
+}
+
+func TestOGEscapesHostileNames(t *testing.T) {
+	srv, p, _, f, h := shareHub(t)
+
+	// The shell needs no storage: shellTitle reads the URL and the project
+	// name, so a hostile project name is enough to exercise it. projectLabel
+	// strips ( and ), so assert against the name the registry actually
+	// stored rather than the literal we asked for.
+	hostile, _, err := srv.Projects.GetOrCreate(`<img src=x onerror=alert1>`, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(hostile.Name, "<img") {
+		t.Fatalf("name was sanitized away: %q", hostile.Name)
+	}
+	shell := do(t, h, "GET", "/"+hostile.ID+`/%22%3E%3Cscript%3E.md`, nil).Body.String()
+
+	f.put("dev1", `"><script>.md`, "# hi\n\n\"><script>alert(1)</script> prose\n")
+	tok, _ := authedShare(t, srv, h, p.ID, `"><script>.md`)
+	share := doHTTP(h, httptest.NewRequest("GET", "/s/"+tok, nil)).Body.String()
+
+	for name, page := range map[string]string{"shell": shell, "share": share} {
+		if len(ogLines(page)) == 0 {
+			t.Errorf("%s: no og tags emitted:\n%s", name, headOf(page))
+			continue
+		}
+		for _, meta := range ogLines(page) {
+			if !strings.HasSuffix(meta, `">`) {
+				t.Errorf("%s: malformed tag %q", name, meta)
+			}
+			for _, bad := range []string{"<script", "<img "} {
+				if strings.Contains(meta, bad) {
+					t.Errorf("%s: unescaped %q in %s", name, bad, meta)
+				}
+			}
+		}
+	}
+	if !strings.Contains(shell, "&lt;img") {
+		t.Errorf("shell did not escape the project name:\n%s", headOf(shell))
+	}
+	if !strings.Contains(share, "&#34;&gt;&lt;script&gt;") {
+		t.Errorf("share did not escape the file name:\n%s", headOf(share))
+	}
+}
+
+// ogLines returns each og: meta tag on a page, for assertions that care about
+// what ended up inside a content= attribute.
+func ogLines(page string) []string {
+	var out []string
+	for rest := page; ; {
+		i := strings.Index(rest, `<meta property="og:`)
+		if i < 0 {
+			return out
+		}
+		rest = rest[i:]
+		j := strings.Index(rest, ">")
+		if j < 0 {
+			return append(out, rest)
+		}
+		out = append(out, rest[:j+1])
+		rest = rest[j+1:]
+	}
+}
+
+func headOf(page string) string {
+	if i := strings.Index(page, "</head>"); i >= 0 {
+		return page[:i]
+	}
+	if len(page) > 600 {
+		return page[:600]
+	}
+	return page
+}

--- a/internal/webapp/server.go
+++ b/internal/webapp/server.go
@@ -912,6 +912,12 @@ func (s *Server) Handler() http.Handler {
 func (s *Server) frontend(static fs.FS) http.HandlerFunc {
 	files := http.FileServerFS(static)
 	index, _ := fs.ReadFile(static, "index.html")
+	// Split the shell around its hardcoded title once, so a per-URL <title>
+	// and og:* block can be spliced into the head without editing (or
+	// rebuilding) frontend/. If the marker is ever gone, `marked` is false
+	// and every request degrades to today's untouched bytes rather than to a
+	// mangled page.
+	pre, post, marked := strings.Cut(string(index), "<title>BearDrive</title>")
 	return func(w http.ResponseWriter, r *http.Request) {
 		upath := strings.TrimPrefix(path.Clean("/"+r.URL.Path), "/")
 		// This document carries the session cookie and drives share creation,
@@ -987,7 +993,21 @@ func (s *Server) frontend(static fs.FS) http.HandlerFunc {
 			return
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.Write(index)
+		// Name the page for unfurlers and crawlers, which never run the JS
+		// that would otherwise set it. Name-derived only: this document is
+		// served with no session, so nothing from inside a file goes in it.
+		// Cache-Control is no-cache here (set above), so varying the head per
+		// URL cannot be cached across URLs; assets/* returned long ago.
+		title := ""
+		if marked {
+			title = s.shellTitle(upath)
+		}
+		if title == "" {
+			w.Write(index)
+			return
+		}
+		io.WriteString(w, pre+titleTag(title)+
+			ogMeta(title, "", "", "website", requestBaseURL(r)+r.URL.EscapedPath())+post)
 	}
 }
 

--- a/internal/webapp/shares.go
+++ b/internal/webapp/shares.go
@@ -609,7 +609,14 @@ func (s *Server) handleShared(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		fmt.Fprintf(cw, sharedMarkdownShell, html.EscapeString(path.Base(sp)), mermaidTag(body), updatedStamp(fi.Time), body)
+		// A share page IS the public copy, so this is the one surface whose
+		// card may describe the content itself, not just name it.
+		base := path.Base(sp)
+		fmPairs, _ := frontmatterPairs(src)
+		og := ogMeta(base, shareDescription(fmPairs, body), shareImage(body),
+			"article", requestBaseURL(r)+r.URL.EscapedPath())
+		fmt.Fprintf(cw, sharedMarkdownShell, html.EscapeString(base), og,
+			mermaidTag(body), updatedStamp(fi.Time), body)
 	case ".html", ".htm":
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		io.Copy(cw, rc)
@@ -649,10 +656,11 @@ func mermaidTag(body string) string {
 }
 
 // sharedMarkdownShell wraps rendered markdown in a minimal readable page.
-// Verbs, in order: title, mermaid script tag (usually empty), updated stamp,
-// body.
+// Verbs, in order: title, Open Graph block, mermaid script tag (usually
+// empty), updated stamp, body. The order is positional and getting it wrong
+// is silent, not a compile error — keep this comment truthful.
 const sharedMarkdownShell = `<!doctype html><html lang="en"><head><meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1"><title>%s</title>
+<meta name="viewport" content="width=device-width, initial-scale=1"><title>%s</title>%s
 <style>
 body{font:16px/1.7 -apple-system,BlinkMacSystemFont,"SF Pro Text","Inter","Segoe UI",sans-serif;color:#24292f;
 max-width:720px;margin:0 auto;padding:52px 24px 96px}


### PR DESCRIPTION
## TL;DR

- Paste any hub link in Slack/Discord/iMessage today and it unfurls naked — every URL served the same `<title>BearDrive</title>` and zero `og:*`. Now it names itself.
- A `/s/<token>` markdown share gets a real card: filename, a description (frontmatter, else the first paragraph), and an image when the document has an absolute one.
- Viewer pages get the **name** only. That shell is served with no session to anyone holding the URL, so nothing from inside a file goes in it.
- `.html` and binary shares are byte-identical to before — the hub still never injects into raw HTML.
- **Known gap:** the browser *tab* still ends up saying "&lt;project&gt; — BearDrive", because `HubApp.tsx` sets `document.title` after mount. Unfurls are fully fixed; the tab is a one-line frontend follow-up the issue's acceptance criteria deliberately ruled out (Risk 1 in the plan).

Closes BEA-181.

## What each surface emits

Two surfaces, and they are deliberately not symmetric.

```mermaid
flowchart TB
    URL["a hub URL is pasted somewhere that unfurls it"]
    SHELL["<div style='text-align:left'><b>SPA shell</b> — /&lt;pid&gt;/&lt;path&gt;<br/>served with NO session<br/><br/>og:title = basename — project<br/>og:site_name, og:type=website, og:url<br/>og:description  never<br/>og:image        never</div>"]
    MD["<div style='text-align:left'><b>/s/&lt;token&gt;</b>, markdown<br/>already public by construction<br/><br/>og:title = basename<br/>og:site_name, og:type=article, og:url<br/>og:description = frontmatter, else 1st para<br/>og:image = 1st absolute http(s) img</div>"]
    RAW["<div style='text-align:left'><b>/s/&lt;token&gt;</b>, .html or binary<br/><br/>no HTML is emitted at all<br/>response byte-identical to today</div>"]
    GEN["<div style='text-align:left'><b>/, /join/&lt;token&gt;, unknown id</b><br/><br/>the untouched shell<br/>&lt;title&gt;BearDrive&lt;/title&gt;</div>"]
    URL --> SHELL
    URL --> MD
    URL --> RAW
    URL --> GEN
```

The asymmetry is the whole design. Name-derived tags (a basename, a project name) go everywhere; content-derived tags (description, image) go only where the content is already public. The issue's answers said "all three tags" *and* gated the image on "publicly accessible" — read together literally that would put a private file's opening lines on a page any crawler can fetch while carefully withholding the image from the same page. The spec resolved it in the conservative direction and this implements that.

## How

One new file, two call sites, nothing under `frontend/`.

- **`internal/webapp/og.go`** — `ogMeta` builds the tag block (everything through `html.EscapeString`; `og:description` and `og:image` emitted only when non-empty, because an empty `og:image` renders a *broken* card rather than none). `shellTitle` names a SPA URL. `shareDescription` / `shareImage` pull from what `handleShared` already holds.
- **`server.go` `frontend()`** — splits the embedded `index.html` around its hardcoded title once at handler-build time, then splices a per-URL head in. If that marker ever disappears the split fails and every request degrades to today's exact bytes rather than to a mangled page.
- **`shares.go`** — one new verb in `sharedMarkdownShell`, in the `.md` branch only. The verb order is positional and getting it wrong is silent rather than a compile error, so the template's doc comment was updated with it.

Three things that are load-bearing and easy to undo by accident:

- **No existence oracle.** An unresolvable project id falls back to the untouched generic shell, so a resolvable id and a bogus one are distinguishable only if you already knew the id. (Project ids are UUIDs or `p-<8 hex>`, per `projectIDRe`; the issue accepted this disclosure explicitly.)
- **No storage access on the shell path.** `shellTitle` reads the URL and one `ProjectDB.Get`, behind a `projectIDRe` guard so a non-project URL never touches the registry mutex. No snapshot, no blob fetch, no journal replay on the hub's hottest handler.
- **`assets/*` is never templated** and keeps `immutable`; the shell keeps `no-cache`, so a per-URL head can't be cached across URLs. Share responses keep `sandbox allow-scripts allow-popups`, `nosniff` and `no-referrer`. Tests pin all of it.

`og:image` insists on an absolute `http(s)` src because `RenderMarkdown` does no src rewriting — a relative `![](diagram.png)` in a shared document is *already* broken on the live share page and resolves against `/s/`. That's a real bug, and a different one.

`og:url` comes from `requestBaseURL`, not `auth.base_url`: the configured origin is only reachable through an unexported method on `*BuiltinAuth`, and `if a, ok := s.Auth.(*BuiltinAuth)` is the exact shape CLAUDE.md records as the bug that broke every push on managed providers. This URL goes back to whoever chose the `Host`, same as the three existing callers.

## Architecture changes

`architecture/webapp-server.md`: one new class, `openGraph` (`og.go`), holding the tag builder, the shell namer and the two share-page content extractors. It is called by `Server` (the SPA shell) and by `ShareDB` (the markdown branch), and it reads `ProjectDB` for the project name and `FrontmatterPair` for the `description` key. `mermaidTag`'s member line moves from *verb 2 of 4* to *verb 3 of 5*, because the shell template gained a verb ahead of it. No fields, interfaces or ownership changed.

> ✅ added · ❌ removed (strikethrough) · unmarked = unchanged

```mermaid
flowchart TB
    Server["<div style='text-align:left'><b>Server</b><br/>+Projects *ProjectDB<br/>+Handler() http.Handler</div>"]
    ShareDB["ShareDB"]
    ProjectDB["ProjectDB"]
    FrontmatterPair["<div style='text-align:left'><b>FrontmatterPair</b><br/>+Key +Value +Code</div>"]
    markdownRender["<div style='text-align:left'><b>markdownRender</b><br/>&lt;&lt;markdown.go&gt;&gt;<br/>frontmatterPairs(src) pairs + body<br/>RenderMarkdown → table + body HTML</div>"]
    mermaidTag["<div style='text-align:left'><b>mermaidTag</b><br/>&lt;&lt;shares.go, the .md branch&gt;&gt;<br/>body contains language-mermaid?<br/><span style='background:#ef444455;padding:0 4px;border-radius:3px'>❌ <s>sharedMarkdownShell verb 2 of 4</s></span><br/><span style='background:#22c55e55;padding:0 4px;border-radius:3px'>✅ sharedMarkdownShell verb 3 of 5</span></div>"]
    openGraph["<div style='text-align:left'><b>openGraph</b><br/>&lt;&lt;og.go&gt;&gt;<br/>ogMeta(title, desc, image, type, url) → meta block<br/>titleTag(s) → &lt;title&gt;<br/>Server.shellTitle(upath) → a name, or empty for today<br/>shareDescription(pairs, body) → fm or 1st para, ≤200<br/>shareImage(body) → 1st absolute http(s) img<br/>sharedMarkdownShell verb 2 of 5</div>"]
    ShareDB -. "markdown shares only" .-> mermaidTag
    ShareDB -. "RenderMarkdown (table stays)" .-> markdownRender
    markdownRender -.-> FrontmatterPair
    ShareDB -. "<span style='background:#22c55e55;padding:0 5px;border-radius:3px'>✅ ogMeta + shareDescription/shareImage (.md branch)</span>" .-> openGraph
    Server -. "<span style='background:#22c55e55;padding:0 5px;border-radius:3px'>✅ shellTitle + titleTag, templated into the SPA shell</span>" .-> openGraph
    openGraph -. "<span style='background:#22c55e55;padding:0 5px;border-radius:3px'>✅ Get(id) for the project name</span>" .-> ProjectDB
    openGraph -. "<span style='background:#22c55e55;padding:0 5px;border-radius:3px'>✅ description key</span>" .-> FrontmatterPair
    classDef added fill:#22c55e22,stroke:#22c55e,stroke-width:2px
    class openGraph added
    linkStyle 3 stroke:#22c55e,stroke-width:2px
    linkStyle 4 stroke:#22c55e,stroke-width:2px
    linkStyle 5 stroke:#22c55e,stroke-width:2px
    linkStyle 6 stroke:#22c55e,stroke-width:2px
```

## What was run

| Check | Result |
| -- | -- |
| `go test ./...` (`-timeout 3h`) | pass, every package |
| `go vet ./...` | clean |
| `npm run e2e` (Playwright, seeded hub) | 202 passed, 1 skipped (a pre-existing `.skip` in `sec14fe.spec.ts`) |
| `internal/webapp/static/index.html` | unmodified — `check-dist.sh` needs no `npm run build`, and no screenshots because no UI changed |

New tests in `internal/webapp/og_test.go`, one per acceptance criterion: tag emission and escaping (including a project named `<img src=x onerror=…>` and a file named `">`), every SPA route shape including an unknown-but-well-formed project id, the anonymous shell fetch, frontmatter-vs-first-paragraph and the 200-char word-boundary truncation, and byte-identity of `.html` and binary share responses.

No CLI, hub-config or on-disk-layout surface changed, so `README.md`, `INSTALL_FOR_AGENTS.md` and `web/docs` need no update.

## The one thing worth deciding

Whether the browser tab matters to you. Unfurls are done; the tab is a one-line `HubApp.tsx` change plus `npm run build` plus a committed `static/`, and it would need `hub.spec.ts:13` and `shell.spec.ts:12` updated with it. Say the word and it's a follow-up PR.

## Build session

```
cd $(git worktree list | grep bea-181-support-og-tag-for-each-page | awk '{print $1}') && claude --resume 5ed1bedb-d086-4bb4-b670-9502ecc04122
```

(Only works on the machine that built this.)
