### PR TITLE
test(daemon): give the spawned helper room to start

### DIFF
--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -168,7 +168,17 @@ func TestStopRecoversLegacyDaemon(t *testing.T) {
 		<-exited
 	}()
 
-	deadline := time.Now().Add(5 * time.Second)
+	// 30s, where the package's other waits use 10s, because this is the only
+	// one that waits on a REAL CHILD PROCESS: os.Args[0] re-invoked, which
+	// boots Go's whole test framework before it reaches the helper and takes
+	// the flock. It had the shortest deadline in the package for its slowest
+	// operation, and duly flaked on a loaded macOS runner (main and a PR, same
+	// line, both green on re-run with no code change).
+	//
+	// The number is only a ceiling on how long a GENUINE failure takes to
+	// report: the loop returns the moment the lock appears, so a healthy run
+	// pays nothing for the headroom.
+	deadline := time.Now().Add(30 * time.Second)
 	for {
 		if _, ok := Running(vdir); ok {
 			break


### PR DESCRIPTION
## TL;DR

- The macOS CI flake that went red on `main` and on #209 today, fixed at the cause.
- `TestStopRecoversLegacyDaemon` gave a spawned child process 5s to take a file lock — the shortest deadline in the package, on its slowest operation.
- 30s. A healthy run pays nothing: the loop returns the moment the lock appears.

## Why 5s was the wrong number

Every other wait in `internal/daemon` uses 10s and polls **in-process** state (`secdmnWaitFor`, `wsWaitFor`). This one is the only place that spawns a **real child**: `exec.Command(os.Args[0], "-test.run=TestHelperLegacyDaemon", ...)`. That child has to boot Go's entire test framework before it reaches the helper and calls `syscall.Flock`.

So it had the tightest budget for the longest operation. On a loaded GitHub macOS runner it doesn't make it:

```
--- FAIL: TestStopRecoversLegacyDaemon (5.01s)
    daemon_test.go:177: helper daemon never took the lock
```

Seen today on `main` (`dd9a5c0`) and on #209, same line, macOS only, **both green on re-run with no code change**. The test dates to #88 (July); nothing in the recent stack touches `internal/daemon`.

## Why the headroom is free

The loop breaks as soon as `Running(vdir)` reports the lock — the deadline is only a ceiling on how long a *genuine* failure takes to report, not a delay any passing run waits out. `go test ./internal/daemon` is 36s here, unchanged.

Deliberately not done: converting this to the package's `waitFor` helpers. They poll in-process state and this waits on a process; folding them together would hide exactly the difference that caused the flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)